### PR TITLE
Provide Symfony 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 
 install:
     - composer require symfony/http-kernel:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
+    - composer require symfony/dotenv:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
     - composer require --dev symfony/framework-bundle:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
     - composer update --prefer-dist
 

--- a/README.md
+++ b/README.md
@@ -27,4 +27,29 @@ ensures that application behaviour will not be affected by stateful services.
             FriendsOfBehat\SymfonyExtension: ~
     ```
 
+**Symfony 3 configuration**
+
+```
+FriendsOfBehat\SymfonyExtension:
+    kernel:
+        bootstrap: 'var/bootstrap.php.cache'
+        path: app/AppKernel.php
+        class: 'AppKernel'
+        env: test
+        debug: true
+```
+
+**Symfony 4 configuration**
+
+```
+FriendsOfBehat\SymfonyExtension:
+    env_file: .env
+    kernel:
+        class: 'MyTrip\Kernel'
+        path: src/Kernel.php
+        debug: true
+```
+
+Symfony 4 does not have bootstrap file anymore and the environment is configured in the .env file.
+
 3. Good luck & have fun!

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 
         "behat/behat": "^3.1",
         "symfony/http-kernel": "^3.3|^4.0",
-        "symfony/dotenv": "^4.0"
+        "symfony/dotenv": "^3.3|^4.0"
     },
     "require-dev": {
         "behat/mink": "^1.7",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": "^7.1",
 
         "behat/behat": "^3.1",
-        "symfony/http-kernel": "^3.3|^4.0"
+        "symfony/http-kernel": "^3.3|^4.0",
+        "symfony/dotenv": "^4.0"
     },
     "require-dev": {
         "behat/mink": "^1.7",

--- a/features/not_crashing_behat.feature
+++ b/features/not_crashing_behat.feature
@@ -67,6 +67,7 @@ Feature: Not crashing Behat
                     kernel:
                         path: src/MyKernel.php
                         class: MyKernel
+                        bootstrap: ~
         """
         And a file ".env_in_memory" containing:
         """

--- a/features/not_crashing_behat.feature
+++ b/features/not_crashing_behat.feature
@@ -56,3 +56,35 @@ Feature: Not crashing Behat
         And a feature file with passing scenario
         When I run Behat
         Then it should pass
+
+    Scenario: This extension boot a Symfony4 kernel
+        Given a Behat configuration containing:
+        """
+        default:
+            extensions:
+                FriendsOfBehat\SymfonyExtension:
+                    env_file: .env_in_memory
+                    kernel:
+                        path: src/MyKernel.php
+                        class: MyKernel
+        """
+        And a file ".env_in_memory" containing:
+        """
+        APP_ENV=dev
+        """
+        And a file "src/MyKernel.php" containing:
+        """
+        <?php
+
+        use Symfony\Component\HttpKernel\Kernel;
+        use Symfony\Component\Config\Loader\LoaderInterface;
+
+        class MyKernel extends Kernel
+        {
+            public function registerBundles() { return []; }
+            public function registerContainerConfiguration(LoaderInterface $loader) {}
+        }
+        """
+        And a feature file with passing scenario
+        When I run Behat
+        Then it should pass

--- a/src/ServiceContainer/SymfonyExtension.php
+++ b/src/ServiceContainer/SymfonyExtension.php
@@ -62,6 +62,16 @@ final class SymfonyExtension implements Extension
     const SHARED_KERNEL_CONTAINER_ID = 'sylius_symfony_extension.shared_kernel.container';
 
     /**
+     * Default symfony environment used to run your suites.
+     */
+    private const DEFAULT_ENV = 'test';
+
+    /**
+     * Enable or disable the debug mode
+     */
+    private const DEBUG_MODE = false;
+
+    /**
      * @var CrossContainerProcessor|null
      */
     private $crossContainerProcessor;
@@ -115,10 +125,11 @@ final class SymfonyExtension implements Extension
         if (null !== $config['env_file']) {
             $this->loadEnvVars($container, $config['env_file']);
 
-            $environment = getenv('APP_ENV');
-            $config['kernel']['env'] = $environment ?? 'test';
-        } else {
-            $this->requireKernelBootstrapFile($container->getParameter('paths.base'), $config['bootstrap']);
+            $environment = false !== getenv('APP_ENV') ? getenv('APP_ENV') : self::DEFAULT_ENV;
+            $debugMode = false !== getenv('APP_DEBUG') ? getenv('APP_DEBUG') : self::DEBUG_MODE;
+
+            $config['kernel']['env'] = $environment;
+            $config['kernel']['kernel'] = $debugMode;
         }
 
         $this->loadKernel($container, $config['kernel']);
@@ -142,7 +153,7 @@ final class SymfonyExtension implements Extension
 
     /**
      * @param ContainerBuilder $container
-     * @param string           $fileName
+     * @param string $fileName
      */
     private function loadEnvVars(ContainerBuilder $container, string $fileName): void
     {
@@ -163,6 +174,8 @@ final class SymfonyExtension implements Extension
         $definition->setFile($this->getKernelFile($container->getParameter('paths.base'), $config['path']));
 
         $container->setDefinition(self::KERNEL_ID, $definition);
+
+        $this->requireKernelBootstrapFile($container->getParameter('paths.base'), $config['bootstrap']);
     }
 
     /**


### PR DESCRIPTION
I am migrating a small project from 3.4 to 4.0 and I am encountering some issues. First, Symfony does not require bootstrap file anymore. Then Symfony uses .env file, that means that Symfony need env variables to work like `APP_ENV`.