### PR TITLE
Proposal: Add autoconfiguration for Symfony 4, other tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,30 +28,40 @@ ensures that application behaviour will not be affected by stateful services.
             FriendsOfBehat\SymfonyExtension: ~
     ```
 
-    **Symfony 3 configuration**
-
-    ```
-    FriendsOfBehat\SymfonyExtension:
-        kernel:
-            bootstrap: 'var/bootstrap.php.cache'
-            path: app/AppKernel.php
-            class: 'AppKernel'
-            env: test
-            debug: true
-    ```
-    
-    **Symfony 4 configuration**
-    
-    ```
-    FriendsOfBehat\SymfonyExtension:
-        # .env.dist file will be used if .env file does not exist  
-        env_file: .env
-        kernel:
-            class: 'MyTrip\Kernel'
-            path: src/Kernel.php
-            debug: true
-    ```
-    
-    Symfony 4 does not have bootstrap file anymore and the environment is configured in the .env file.
-
 3. Good luck & have fun!
+
+    
+## Configuration
+
+SymfonyExtension provides kind of autoconfiguration feature.
+When none explicit configuration is set, we will set for You sane default that will get you running fast.
+
+**Default Symfony 3 configuration**
+
+```
+FriendsOfBehat\SymfonyExtension:
+    kernel:
+        bootstrap: 'app/autoload.php' # you may want to use var/bootstrap.php.cache instead
+        path: app/AppKernel.php
+        class: 'AppKernel'
+        env: test
+        debug: true
+```
+
+**Default Symfony 4 configuration**
+
+```
+FriendsOfBehat\SymfonyExtension:
+    # .env.dist file will be used if .env file does not exist
+    env_file: .env
+    kernel:
+        bootstrap: ~
+        path: src/Kernel.php
+        class: 'App\Kernel'
+        env: test # When explicitly set, will override APP_ENV loaded from env_file file
+        debug: true  # When explicitly set, will override APP_DEBUG loaded from env_file file
+```
+
+Symfony 4 is detected, based on the existence of `src/Kernel.php` file, so if you did not migrate to new Symfony structure yet; you need to set those values yourself.
+
+Of course, you can always change each of those settings.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ FriendsOfBehat\SymfonyExtension:
         debug: true  # When explicitly set, will override APP_DEBUG loaded from env_file file
 ```
 
-Symfony 4 is detected, based on the existence of `src/Kernel.php` file, so if you did not migrate to new Symfony structure yet; you need to set those values yourself.
+Symfony 4 is automatically detected, based on the existence of default `src/Kernel.php` kernel file.
+
+If you did not migrate to new Symfony structure yet or you are using custom paths/naming; you need to configure `kernel.boostrap` parameter, to enable default Symfony 4 configuration as shown in the example below:
+
+```
+FriendsOfBehat\SymfonyExtension:
+    # env_file: .env # loaded from the default configuration
+    kernel:
+        bootstrap: ~ # this enables default Symfony 4 configuration
+        path: app/AppKernel.php
+        # class: 'App\Kernel' # loaded from the default configuration
+        # env: test # loaded from the default configuration
+        # debug: true  # loaded from the default configuration
+```
 
 Of course, you can always change each of those settings.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ensures that application behaviour will not be affected by stateful services.
 ## Configuration
 
 SymfonyExtension provides kind of autoconfiguration feature.
-When none explicit configuration is set, we will set for You sane default that will get you running fast.
+When none explicit configuration is set, we will set for you sane default that will get you running fast.
 
 **Default Symfony 3 configuration**
 
@@ -64,7 +64,7 @@ FriendsOfBehat\SymfonyExtension:
 
 Symfony 4 is automatically detected, based on the existence of default `src/Kernel.php` kernel file.
 
-If you did not migrate to new Symfony structure yet or you are using custom paths/naming; you need to configure `kernel.boostrap` parameter, to enable default Symfony 4 configuration as shown in the example below:
+If you did not migrate to new Symfony structure yet or you are using custom paths/naming; you need to configure `kernel.bootstrap` parameter, to enable default Symfony 4 configuration as shown in the example below:
 
 ```
 FriendsOfBehat\SymfonyExtension:

--- a/features/not_crashing_behat.feature
+++ b/features/not_crashing_behat.feature
@@ -8,9 +8,12 @@ Feature: Not crashing Behat
         """
         default:
             extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    kernel:
-                        bootstrap: ~
+                FriendsOfBehat\SymfonyExtension: ~
+        """
+        And a file "app/autoload.php" containing:
+        """
+        <?php
+
         """
         And a file "app/AppKernel.php" containing:
         """
@@ -36,11 +39,16 @@ Feature: Not crashing Behat
             extensions:
                 FriendsOfBehat\SymfonyExtension:
                     kernel:
-                        bootstrap: ~
+                        bootstrap: app/autoload.php
                         path: app/MyKernel.php
                         class: MyKernel
                         env: test
                         debug: true
+        """
+        And a file "app/autoload.php" containing:
+        """
+        <?php
+
         """
         And a file "app/MyKernel.php" containing:
         """
@@ -163,11 +171,13 @@ Feature: Not crashing Behat
         """
         default:
             extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    kernel:
-                        bootstrap: ~
-
+                FriendsOfBehat\SymfonyExtension: ~
                 FriendsOfBehat\CrossContainerExtension: ~
+        """
+        And a file "app/autoload.php" containing:
+        """
+        <?php
+
         """
         And a file "app/AppKernel.php" containing:
         """

--- a/features/not_crashing_behat.feature
+++ b/features/not_crashing_behat.feature
@@ -3,7 +3,7 @@ Feature: Not crashing Behat
     As a Behat User
     I want to have Behat up and running after enabling this extension
 
-    Scenario: Not crashing Behat
+    Scenario: Successful boot the Symfony kernel with autoconfiguration
         Given a Behat configuration containing:
         """
         default:
@@ -29,7 +29,7 @@ Feature: Not crashing Behat
         When I run Behat
         Then it should pass
 
-    Scenario: Not crashing Behat with CrossContainerExtension
+    Scenario: Successful boot the Symfony kernel with explicit configuration
         Given a Behat configuration containing:
         """
         default:
@@ -37,17 +37,19 @@ Feature: Not crashing Behat
                 FriendsOfBehat\SymfonyExtension:
                     kernel:
                         bootstrap: ~
-
-                FriendsOfBehat\CrossContainerExtension: ~
+                        path: app/MyKernel.php
+                        class: MyKernel
+                        env: test
+                        debug: true
         """
-        And a file "app/AppKernel.php" containing:
+        And a file "app/MyKernel.php" containing:
         """
         <?php
 
         use Symfony\Component\HttpKernel\Kernel;
         use Symfony\Component\Config\Loader\LoaderInterface;
 
-        class AppKernel extends Kernel
+        class MyKernel extends Kernel
         {
             public function registerBundles() { return []; }
             public function registerContainerConfiguration(LoaderInterface $loader) {}
@@ -57,7 +59,38 @@ Feature: Not crashing Behat
         When I run Behat
         Then it should pass
 
-    Scenario: This extension boot a Symfony4 kernel
+
+    Scenario: Successful boot the Symfony 4 kernel with autoconfiguration
+        Given a Behat configuration containing:
+        """
+        default:
+            extensions:
+                FriendsOfBehat\SymfonyExtension: ~
+        """
+        And a file ".env" containing:
+        """
+        APP_ENV=dev
+        """
+        And a file "src/Kernel.php" containing:
+        """
+        <?php
+
+        namespace App;
+
+        use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+        use Symfony\Component\Config\Loader\LoaderInterface;
+
+        class Kernel extends BaseKernel
+        {
+            public function registerBundles() { return []; }
+            public function registerContainerConfiguration(LoaderInterface $loader) {}
+        }
+        """
+        And a feature file with passing scenario
+        When I run Behat
+        Then it should pass
+
+    Scenario: Successful boot the Symfony 4 kernel with explicit configuration
         Given a Behat configuration containing:
         """
         default:
@@ -98,9 +131,11 @@ Feature: Not crashing Behat
                 FriendsOfBehat\SymfonyExtension:
                     env_file: .env_in_memory
                     kernel:
+                        bootstrap: ~
                         path: src/MyKernel.php
                         class: MyKernel
-                        bootstrap: ~
+                        env: dev
+                        debug: true
         """
         And a file ".env_in_memory.dist" containing:
         """
@@ -114,6 +149,34 @@ Feature: Not crashing Behat
         use Symfony\Component\Config\Loader\LoaderInterface;
 
         class MyKernel extends Kernel
+        {
+            public function registerBundles() { return []; }
+            public function registerContainerConfiguration(LoaderInterface $loader) {}
+        }
+        """
+        And a feature file with passing scenario
+        When I run Behat
+        Then it should pass
+
+    Scenario: Not crashing Behat with CrossContainerExtension
+        Given a Behat configuration containing:
+        """
+        default:
+            extensions:
+                FriendsOfBehat\SymfonyExtension:
+                    kernel:
+                        bootstrap: ~
+
+                FriendsOfBehat\CrossContainerExtension: ~
+        """
+        And a file "app/AppKernel.php" containing:
+        """
+        <?php
+
+        use Symfony\Component\HttpKernel\Kernel;
+        use Symfony\Component\Config\Loader\LoaderInterface;
+
+        class AppKernel extends Kernel
         {
             public function registerBundles() { return []; }
             public function registerContainerConfiguration(LoaderInterface $loader) {}

--- a/src/ServiceContainer/SymfonyExtension.php
+++ b/src/ServiceContainer/SymfonyExtension.php
@@ -122,8 +122,9 @@ final class SymfonyExtension implements Extension
             ->children()
                 ->scalarNode('env_file')->end()
                 ->arrayNode('kernel')
+                    ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('bootstrap')->end()
+                        ->scalarNode('bootstrap')->defaultFalse()->end()
                         ->scalarNode('path')->end()
                         ->scalarNode('class')->end()
                         ->scalarNode('env')->end()
@@ -165,14 +166,16 @@ final class SymfonyExtension implements Extension
      * @param array $userConfig
      * @return array
      */
-    private function autoconfigure(ContainerBuilder $container, array $userConfig) {
-
+    private function autoconfigure(ContainerBuilder $container, array $userConfig): array
+    {
         $defaults = self::SYMFONY_DEFAULTS;
 
-        $symfony4KernelPath = sprintf('%s/%s', $container->getParameter('paths.base'), self::SYMFONY_4_DEFAULTS['kernel']['path']);
-        if (file_exists($symfony4KernelPath)) {
+        $symfonyFourKernelPath = sprintf('%s/%s', $container->getParameter('paths.base'), self::SYMFONY_4_DEFAULTS['kernel']['path']);
+        if ($userConfig['kernel']['bootstrap'] === null || file_exists($symfonyFourKernelPath)) {
             $defaults = self::SYMFONY_4_DEFAULTS;
         }
+
+        $userConfig['kernel']['bootstrap'] = $userConfig['kernel']['bootstrap'] === false ? null : $userConfig['kernel']['bootstrap'];
 
         $config = array_replace_recursive($defaults, $userConfig);
 

--- a/src/ServiceContainer/SymfonyExtension.php
+++ b/src/ServiceContainer/SymfonyExtension.php
@@ -61,7 +61,35 @@ final class SymfonyExtension implements Extension
     /**
      * Enable or disable the debug mode
      */
-    private const DEBUG_MODE = false;
+    private const DEFAULT_DEBUG_MODE = true;
+
+    /**
+     * Default Symfony configuration
+     */
+    private const SYMFONY_DEFAULTS = [
+        'env_file' => null,
+        'kernel' => [
+            'bootstrap' => 'app/autoload.php',
+            'path' => 'app/AppKernel.php',
+            'class' => 'AppKernel',
+            'env' => self::DEFAULT_ENV,
+            'debug' => self::DEFAULT_DEBUG_MODE
+        ]
+    ];
+
+    /**
+     * Default Symfony 4 configuration
+     */
+    private const SYMFONY_4_DEFAULTS = [
+        'env_file' => '.env',
+        'kernel' => [
+            'bootstrap' => null,
+            'path' => 'src/Kernel.php',
+            'class' => 'App\Kernel',
+            'env' => self::DEFAULT_ENV,
+            'debug' => self::DEFAULT_DEBUG_MODE
+        ]
+    ];
 
     /**
      * @var CrossContainerProcessor|null
@@ -91,18 +119,15 @@ final class SymfonyExtension implements Extension
     public function configure(ArrayNodeDefinition $builder): void
     {
         $builder
-            ->addDefaultsIfNotSet()
-                ->children()
-                    ->scalarNode('env_file')->defaultNull()->end()
-                    ->arrayNode('kernel')
-                        ->addDefaultsIfNotSet()
-                        ->children()
-                            ->scalarNode('bootstrap')->defaultValue('app/autoload.php')->end()
-                            ->scalarNode('path')->defaultValue('app/AppKernel.php')->end()
-                            ->scalarNode('class')->defaultValue('AppKernel')->end()
-                            ->scalarNode('env')->defaultValue('test')->end()
-                            ->booleanNode('debug')->defaultTrue()->end()
-                        ->end()
+            ->children()
+                ->scalarNode('env_file')->end()
+                ->arrayNode('kernel')
+                    ->children()
+                        ->scalarNode('bootstrap')->end()
+                        ->scalarNode('path')->end()
+                        ->scalarNode('class')->end()
+                        ->scalarNode('env')->end()
+                        ->booleanNode('debug')->end()
                     ->end()
                 ->end()
             ->end()
@@ -114,17 +139,7 @@ final class SymfonyExtension implements Extension
      */
     public function load(ContainerBuilder $container, array $config): void
     {
-        if (null !== $config['env_file']) {
-            $envFilePath = sprintf('%s/%s', $container->getParameter('paths.base'), $config['env_file']);
-            $envFilePath = file_exists($envFilePath) ? $envFilePath : $envFilePath.'.dist';
-            (new Dotenv())->load($envFilePath);
-
-            $environment = false !== getenv('APP_ENV') ? getenv('APP_ENV') : self::DEFAULT_ENV;
-            $debugMode = false !== getenv('APP_DEBUG') ? getenv('APP_DEBUG') : self::DEBUG_MODE;
-
-            $config['kernel']['env'] = $environment;
-            $config['kernel']['kernel'] = $debugMode;
-        }
+        $config = $this->autoconfigure($container, $config);
 
         $this->loadKernel($container, $config['kernel']);
         $this->loadKernelContainer($container);
@@ -143,6 +158,47 @@ final class SymfonyExtension implements Extension
      */
     public function process(ContainerBuilder $container): void
     {
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array $userConfig
+     * @return array
+     */
+    private function autoconfigure(ContainerBuilder $container, array $userConfig) {
+
+        $defaults = self::SYMFONY_DEFAULTS;
+
+        $symfonyFlexKernelPath = sprintf('%s/%s', $container->getParameter('paths.base'), self::SYMFONY_4_DEFAULTS['kernel']['path']);
+        if (file_exists($symfonyFlexKernelPath)) {
+            $defaults = self::SYMFONY_4_DEFAULTS;
+        }
+
+        $config = array_replace_recursive($defaults, $userConfig);
+
+        if (null !== $config['env_file']) {
+            $this->loadEnvVars($container, $config['env_file']);
+
+            if (!isset($userConfig['kernel']['env']) && false !== getenv('APP_ENV')) {
+                $config['kernel']['env'] = getenv('APP_ENV');
+            }
+
+            if (!isset($userConfig['kernel']['debug']) && false !== getenv('APP_DEBUG')) {
+                $config['kernel']['debug'] = getenv('APP_DEBUG');
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param string $fileName
+     */
+    private function loadEnvVars(ContainerBuilder $container, string $fileName): void
+    {
+        $envFilePath = sprintf('%s/%s', $container->getParameter('paths.base'), $fileName);
+        (new Dotenv())->load($envFilePath);
     }
 
     /**

--- a/src/ServiceContainer/SymfonyExtension.php
+++ b/src/ServiceContainer/SymfonyExtension.php
@@ -73,8 +73,8 @@ final class SymfonyExtension implements Extension
             'path' => 'app/AppKernel.php',
             'class' => 'AppKernel',
             'env' => self::DEFAULT_ENV,
-            'debug' => self::DEFAULT_DEBUG_MODE
-        ]
+            'debug' => self::DEFAULT_DEBUG_MODE,
+        ],
     ];
 
     /**
@@ -87,8 +87,8 @@ final class SymfonyExtension implements Extension
             'path' => 'src/Kernel.php',
             'class' => 'App\Kernel',
             'env' => self::DEFAULT_ENV,
-            'debug' => self::DEFAULT_DEBUG_MODE
-        ]
+            'debug' => self::DEFAULT_DEBUG_MODE,
+        ],
     ];
 
     /**
@@ -161,11 +161,6 @@ final class SymfonyExtension implements Extension
     {
     }
 
-    /**
-     * @param ContainerBuilder $container
-     * @param array $userConfig
-     * @return array
-     */
     private function autoconfigure(ContainerBuilder $container, array $userConfig): array
     {
         $defaults = self::SYMFONY_DEFAULTS;
@@ -194,19 +189,13 @@ final class SymfonyExtension implements Extension
         return $config;
     }
 
-    /**
-     * @param ContainerBuilder $container
-     * @param string $fileName
-     */
     private function loadEnvVars(ContainerBuilder $container, string $fileName): void
     {
         $envFilePath = sprintf('%s/%s', $container->getParameter('paths.base'), $fileName);
+        $envFilePath = file_exists($envFilePath) ? $envFilePath : $envFilePath . '.dist';
         (new Dotenv())->load($envFilePath);
     }
 
-    /**
-     * @param ContainerBuilder $container
-     */
     private function loadKernel(ContainerBuilder $container, array $config): void
     {
         $definition = new Definition($config['class'], [
@@ -226,9 +215,6 @@ final class SymfonyExtension implements Extension
         $this->requireKernelBootstrapFile($container->getParameter('paths.base'), $config['bootstrap']);
     }
 
-    /**
-     * @param ContainerBuilder $container
-     */
     private function loadKernelContainer(ContainerBuilder $container): void
     {
         $containerDefinition = new Definition(Container::class);
@@ -240,25 +226,16 @@ final class SymfonyExtension implements Extension
         $container->setDefinition(self::KERNEL_CONTAINER_ID, $containerDefinition);
     }
 
-    /**
-     * @param ContainerBuilder $container
-     */
     private function loadDriverKernel(ContainerBuilder $container): void
     {
         $container->setDefinition(self::DRIVER_KERNEL_ID, $container->findDefinition(self::KERNEL_ID));
     }
 
-    /**
-     * @param ContainerBuilder $container
-     */
     private function loadSharedKernel(ContainerBuilder $container): void
     {
         $container->setDefinition(self::SHARED_KERNEL_ID, $container->findDefinition(self::KERNEL_ID));
     }
 
-    /**
-     * @param ContainerBuilder $container
-     */
     private function loadSharedKernelContainer(ContainerBuilder $container): void
     {
         $containerDefinition = new Definition(Container::class);
@@ -271,8 +248,6 @@ final class SymfonyExtension implements Extension
     }
 
     /**
-     * @param ContainerBuilder $container
-     *
      * @throws \Exception
      */
     private function loadKernelRebooter(ContainerBuilder $container): void
@@ -284,8 +259,6 @@ final class SymfonyExtension implements Extension
     }
 
     /**
-     * @param ContainerBuilder $container
-     *
      * @throws \Exception
      */
     private function declareSymfonyContainers(ContainerBuilder $container): void
@@ -316,9 +289,6 @@ final class SymfonyExtension implements Extension
         }
     }
 
-    /**
-     * @param ExtensionManager $extensionManager
-     */
     private function initializeCrossContainerProcessor(ExtensionManager $extensionManager): void
     {
         /** @var CrossContainerExtension $extension */
@@ -328,9 +298,6 @@ final class SymfonyExtension implements Extension
         }
     }
 
-    /**
-     * @param ExtensionManager $extensionManager
-     */
     private function registerSymfonyDriverFactory(ExtensionManager $extensionManager): void
     {
         /** @var MinkExtension|null $minkExtension */
@@ -345,12 +312,6 @@ final class SymfonyExtension implements Extension
         ));
     }
 
-    /**
-     * @param string $basePath
-     * @param string $kernelPath
-     *
-     * @return string|null
-     */
     private function getKernelFile(string $basePath, string $kernelPath): ?string
     {
         $possibleFiles = [
@@ -368,9 +329,6 @@ final class SymfonyExtension implements Extension
     }
 
     /**
-     * @param string $basePath
-     * @param string|null $bootstrapPath
-     *
      * @throws \DomainException
      */
     private function requireKernelBootstrapFile(string $basePath, ?string $bootstrapPath): void

--- a/src/ServiceContainer/SymfonyExtension.php
+++ b/src/ServiceContainer/SymfonyExtension.php
@@ -169,8 +169,8 @@ final class SymfonyExtension implements Extension
 
         $defaults = self::SYMFONY_DEFAULTS;
 
-        $symfonyFlexKernelPath = sprintf('%s/%s', $container->getParameter('paths.base'), self::SYMFONY_4_DEFAULTS['kernel']['path']);
-        if (file_exists($symfonyFlexKernelPath)) {
+        $symfony4KernelPath = sprintf('%s/%s', $container->getParameter('paths.base'), self::SYMFONY_4_DEFAULTS['kernel']['path']);
+        if (file_exists($symfony4KernelPath)) {
             $defaults = self::SYMFONY_4_DEFAULTS;
         }
 


### PR DESCRIPTION
So this is my proposal for SymfonyExtension. Related to #28 

What it changes:

1. Adds autoconfiguration for Symfony 4 (when default `src/Kernel.php` is detected); Improves DX.

So when project bein compliant with new Symfony 4 structure, the configuration will look like:
```
            extensions:
                FriendsOfBehat\SymfonyExtension: ~
```
The standard `.env` file is loaded by default.

2. Explicit settings of `env` and `debug` parameters will override the configuration loaded from `.env` file. This also improves DX, as there is no need for hacky workarounds to get behat working.

3. Fixed issue with the badly named configuration `$config['kernel']['kernel'] = $debugMode;` in 1a39d31f5e457cc6b44701a7bef99ba14f5c0cb2

4. Tweaked README to include new configuration details


When it might seem only like an improvement, it's required to get behat working on new Symfony 4 structure when you: do not want to store a separate copy of `.env` with only `APP_ENV` changed to `test`, do not want to change those settings back and forth in `.env` file; which I consider not good practice and not good DX for sure 😄 