### PR TITLE
Make definitions public, ensures kernels are not inlined and duplicated

### DIFF
--- a/src/ServiceContainer/SymfonyExtension.php
+++ b/src/ServiceContainer/SymfonyExtension.php
@@ -172,6 +172,7 @@ final class SymfonyExtension implements Extension
         ));
         $definition->addMethodCall('boot');
         $definition->setFile($this->getKernelFile($container->getParameter('paths.base'), $config['path']));
+        $definition->setPublic(true);
 
         $container->setDefinition(self::KERNEL_ID, $definition);
 


### PR DESCRIPTION
Hello!

I've been trying to track down some strange behaviour for the past few days related to the separate kernels in this extension and believe I've found the cause / solution.

Specifically, it seems that when used with the CrossContainerExtension, the kernel registered as the `sylius_symfony_extension.driver_kernel` that is also used for the KernelBasedContainerAccessor is _not_ the same kernel instance that is used for the Mink SymfonyDriver, but that actually two different driver kernel instances are booted - one for the Mink driver, one for the CrossContainerExtension.

Since the SymfonyDriver for Mink uses a `Reference` to this kernel, and the CrossContainerExtension uses `ContainerBuilder::get`, there is only one reference in the entire Behat container to the driver kernel.

When the container is compiled, the `InlineServiceDefinitionsPass` is run, and realises that the driver kernel reference is only used by the Mink SymfonyDriver, which inlines the definition since it believes that it is only used in this single service. The inlining of this `Reference` to a `Definition` causes an entirely new kernel to be created & booted for the Mink SymfonyDriver rather than re-using the one we've already given to the CrossContainerExtension.

A simple way to fix this is to mark the kernel definitions as public, which prevents them from being inlined, and ensures that the same kernel is given to the CrossContainerExtension and the Mink SymfonyDriver.

I've created a bare minimum repository to demonstrate this behaviour - [https://github.com/Persata/fob-kernel-example](https://github.com/Persata/fob-kernel-example). You should be able to clone it, `composer install` and run `vendor/bin/behat` without any additional setup.

What I've done is injected a service from the driver kernel into my context to modify it before the request is sent, as a kind of "test double". Without setting the kernel definitions to public, 4 kernels are booted in total before the request is sent (I've added some comments using #):

```console
$ vendor/bin/behat
Booting new kernel! # This is the `sylius_symfony_extension.kernel`, booted here inside `loadKernelRebooter`.
Booting new kernel! # This is the `sylius_symfony_extension.driver_kernel`, booted here inside `declareSymfonyContainers`.
Booting new kernel! # This is the `sylius_symfony_extension.shared_kernel`, also booted inside `declareSymfonyContainers`.
Booting new kernel! # This is the duplicate `sylius_symfony_extension.driver_kernel` booted from the inlined Reference mentioned above.
Feature: Viewing the greeter text on the homepage

  Scenario:
    Given the greeter should say "Bonjour World!"
    When I am on the homepage
    Then I should see text matching "Bonjour World!"
      The pattern "Bonjour World!" was not found anywhere in the text of the current page. (Behat\Mink\Exception\ResponseTextException) 

Booting new kernel! # This is the `sylius_symfony_extension.kernel`, re-booted by the `KernelRebooter`.
--- Failed scenarios:

    features/hello_world.feature:3
```

The test fails because the service in my `GreeterContext` and the service in the driver are from two different kernels, so my overwriting of the output affects the wrong kernel.

When the kernel definitions are set to public, this is the output (to test this I just modify the SymfonyExtension inside the `vendor` folder):

```console
$ vendor/bin/behat
Booting new kernel! # This is the `sylius_symfony_extension.kernel`, booted here inside `loadKernelRebooter`.
Booting new kernel! # This is the `sylius_symfony_extension.driver_kernel`, booted here inside `declareSymfonyContainers`.
Booting new kernel! # This is the `sylius_symfony_extension.shared_kernel`, also booted inside `declareSymfonyContainers`.
Feature: Viewing the greeter text on the homepage

  Scenario:
    Given the greeter should say "Bonjour World!"
    When I am on the homepage
    Then I should see text matching "Bonjour World!"

Booting new kernel! # This is the `sylius_symfony_extension.kernel`, re-booted by the `KernelRebooter`.
1 scenario (1 passed)
3 steps (3 passed)
0m0.05s (15.94Mb)
```

The test now passes because the service given to my `GreeterContext` and to the driver are from the same kernel.

I believe this is also related to #25 / #27, and by setting the definitions to public meant using the original `Reference` instead of `ContainerBuilder::get` had the correct behaviour, but would be best if @arnolanglade could verify this too.

I've also tested this change with the Sylius Behat suite that uses SymfonyDriver and everything passed accordingly, so it hasn't broken anything there.

Apologies for the wall of text, but I wanted to be thorough!

Let me know if I can provide any more information.