### PR TITLE
Remove support for Symfony 4.1 as it's EOLed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
 
 env:
     - SYMFONY_VERSION=3.4.*
-    - SYMFONY_VERSION=4.1.*
     - SYMFONY_VERSION=4.2.*
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "require": {
         "php": "^7.1",
         "behat/behat": "^3.4",
-        "symfony/dependency-injection": "^3.4.10|^4.1",
-        "symfony/http-kernel": "^3.4|^4.1",
-        "symfony/proxy-manager-bridge": "^3.4|^4.1"
+        "symfony/dependency-injection": "^3.4.10|^4.2",
+        "symfony/http-kernel": "^3.4|^4.2",
+        "symfony/proxy-manager-bridge": "^3.4|^4.2"
     },
     "require-dev": {
         "behat/mink": "^1.7",
@@ -23,11 +23,8 @@
         "behat/mink-extension": "^2.2",
         "phpstan/phpstan-shim": "^0.11",
         "sylius-labs/coding-standard": "^3.0",
-        "symfony/framework-bundle": "^3.4|^4.1",
-        "symfony/yaml": "^3.4|^4.1"
-    },
-    "conflict": {
-        "symfony/dependency-injection": "4.1.11"
+        "symfony/framework-bundle": "^3.4|^4.2",
+        "symfony/yaml": "^3.4|^4.2"
     },
     "suggest": {
         "behat/mink-browserkit-driver": "^1.3"


### PR DESCRIPTION
This targets the master branch, the future `v2.1.0` release.