### PR TITLE
Revert mink parameters autoconfiguration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.1",
         "behat/behat": "^3.4",
-        "symfony/dependency-injection": "^3.4.10|^4.1",
+        "symfony/dependency-injection": "^3.4|^4.1",
         "symfony/http-kernel": "^3.4|^4.1",
         "symfony/proxy-manager-bridge": "^3.4|^4.1"
     },
@@ -25,9 +25,6 @@
         "sylius-labs/coding-standard": "^3.0",
         "symfony/framework-bundle": "^3.4|^4.1",
         "symfony/yaml": "^3.4|^4.1"
-    },
-    "conflict": {
-        "symfony/dependency-injection": "4.1.11"
     },
     "suggest": {
         "behat/mink-browserkit-driver": "^1.3"

--- a/docs/03_mink_integration.md
+++ b/docs/03_mink_integration.md
@@ -31,5 +31,5 @@ This integration provides two services to use inside Symfony container:
 
  * **`behat.mink.default_session`** (autowired by `\Behat\Mink\Session`) - the default Mink session for the current scenario
  
- * **`behat.mink.parameters`** (autoconfigured by `$minkParameters`) - an array (`\ArrayAccess` object) containing the 
- configuration parameters of `MinkExtension`
+ * **`behat.mink.parameters`** (autowired by `\FriendsOfBehat\SymfonyExtension\Mink\MinkParameters`) - an object 
+ containing the configuration parameters of `MinkExtension` (implementing `\ArrayAccess` so that it can be treated as an array)

--- a/features/mink_integration/mink_integration_with_dependency_injection.feature
+++ b/features/mink_integration/mink_integration_with_dependency_injection.feature
@@ -39,22 +39,15 @@ Feature: Mink integration with dependency injection
 
         use Behat\Behat\Context\Context;
         use Behat\Mink\Session;
+        use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
         use Psr\Container\ContainerInterface;
 
         final class SomeContext implements Context {
             private $session;
             private $parameters;
 
-            public function __construct(Session $session, $minkParameters)
+            public function __construct(Session $session, MinkParameters $minkParameters)
             {
-                if (!is_array($minkParameters) && !$minkParameters instanceof \ArrayAccess) {
-                    throw new \InvalidArgumentException(sprintf(
-                        '"$parameters" passed to "%s" has to be an array or implement "%s".',
-                        self::class,
-                        \ArrayAccess::class
-                    ));
-                }
-
                 $this->session = $session;
                 $this->parameters = $minkParameters;
             }

--- a/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
+++ b/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
@@ -47,12 +47,6 @@ final class FriendsOfBehatSymfonyExtensionExtension extends Extension implements
     {
         $this->registerMinkDefaultSession($container);
         $this->registerMinkParameters($container);
-
-        $autoconfiguredContextPrototype = $container->registerForAutoconfiguration(Context::class);
-        $autoconfiguredContextPrototype->setBindings(array_merge(
-            $autoconfiguredContextPrototype->getBindings(),
-            ['$minkParameters' => new Reference('behat.mink.parameters')]
-        ));
     }
 
     private function registerMinkDefaultSession(ContainerBuilder $container): void


### PR DESCRIPTION
According to #63 and #54, it looks like the way we used autoconfiguration to bind `$minkParameters` variable was abusing the Symfony's Dependency Injection API and is not officially supported. I'm removing that possibility, because it's very unstable and prevents library adoption.