### PR TITLE
Hotfix for weird bug in Sylius

### DIFF
--- a/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
+++ b/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
@@ -54,7 +54,6 @@ final class FriendsOfBehatSymfonyExtensionExtension extends Extension implements
     {
         $minkDefinition = new Definition(Mink::class, ['mink']);
         $minkDefinition->setPublic(true);
-        $minkDefinition->setLazy(true);
         $minkDefinition->setFactory([new Reference('behat.service_container'), 'get']);
 
         $container->setDefinition('behat.mink', $minkDefinition);


### PR DESCRIPTION
Couldn't reproduce it, removing that lazy setting fixes the issue though.

There's a quite random error:

```
LogicException: The page history is empty. in vendor/symfony/browser-kit/History.php:95
```

It happens when sending a form or clicking a link, but not always. Ex. when running the whole directory of features, one scenario in a subdirectory fails. When running that scenario only, it passes. When running that scenario in between of other scenarios in that directory, it still passes.

https://travis-ci.org/Sylius/Sylius/jobs/507555578#L1787