### PR TITLE
[Symfony 4.3] Allow AbstractBrowser instance next to Client as test.client service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - SYMFONY_VERSION=3.4.*
     - SYMFONY_VERSION=4.1.*
     - SYMFONY_VERSION=4.2.*
+    - SYMFONY_VERSION=4.3.x-dev
 
 cache:
     directories:
@@ -22,7 +23,7 @@ install:
     - composer require symfony/http-kernel:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
     - composer require symfony/proxy-manager-bridge:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
     - composer require --dev symfony/framework-bundle:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
-    - composer update --prefer-dist
+    - if [ "$SYMFONY_VERSION" == "4.3.x-dev" ]; then composer update --stability dev --prefer-stable --prefer-dist; else composer update --prefer-dist; fi
 
 script:
     - composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "behat/behat": "^3.4",
         "symfony/dependency-injection": "^3.4|^4.1",
         "symfony/http-kernel": "^3.4|^4.1",
-        "symfony/proxy-manager-bridge": "^3.4|^4.1"
+        "symfony/proxy-manager-bridge": "4.3.x-dev"
     },
     "require-dev": {
         "behat/mink": "^1.7",

--- a/src/Driver/SymfonyDriver.php
+++ b/src/Driver/SymfonyDriver.php
@@ -6,6 +6,7 @@ namespace FriendsOfBehat\SymfonyExtension\Driver;
 
 use Behat\Mink\Driver\BrowserKitDriver;
 use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 final class SymfonyDriver extends BrowserKitDriver
@@ -24,10 +25,11 @@ final class SymfonyDriver extends BrowserKitDriver
 
         $testClient = $kernel->getContainer()->get('test.client');
 
-        if (!$testClient instanceof Client) {
+        if (!$testClient instanceof Client && !$testClient instanceof AbstractBrowser) {
             throw new \RuntimeException(sprintf(
-                'Service "test.client" should be an instance of "%s", "%s" given.',
+                'Service "test.client" should be an instance of "%s" or "%s", "%s" given.',
                 Client::class,
+                AbstractBrowser::class,
                 get_class($testClient)
             ));
         }


### PR DESCRIPTION
Thanks for this cool extension!

The `SymfonyDriver` uses `test.client`. In Symfony 4.3 `test.client` is an instance of `\Symfony\Bundle\FrameworkBundle\KernelBrowser` which is no longer a descendant of `\Symfony\Component\BrowserKit\Client` but of `\Symfony\Component\BrowserKit\AbstractBrowser`.

This PR works around this by checking whether `test.client` is either a `Client` or `AbstractBrowser`.