### PR TITLE
Provide simple BrowserKit integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
     - composer require symfony/dependency-injection:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
     - composer require symfony/http-kernel:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
     - composer require symfony/proxy-manager-bridge:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
+    - composer require --dev symfony/browser-kit:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
     - composer require --dev symfony/framework-bundle:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
     - composer require --dev symfony/yaml:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
     - composer update --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "friends-of-behat/service-container-extension": "^1.0",
         "phpstan/phpstan-shim": "^0.11",
         "sylius-labs/coding-standard": "^3.0",
+        "symfony/browser-kit": "^3.4|^4.2",
         "symfony/framework-bundle": "^3.4|^4.2",
         "symfony/yaml": "^3.4|^4.2"
     },

--- a/features/browserkit_integration/browserkit_integration.feature
+++ b/features/browserkit_integration/browserkit_integration.feature
@@ -1,0 +1,81 @@
+Feature: BrowserKit integration
+
+    Background:
+        Given a working Symfony application with SymfonyExtension configured
+        And a Behat configuration containing:
+        """
+        default:
+            suites:
+                default:
+                    contexts:
+                        - App\Tests\SomeContext
+        """
+        And a feature file containing:
+        """
+        Feature:
+            Scenario:
+                When I visit the page "/hello-world"
+                Then I should see "Hello world!" on the page
+
+            # Doubling the scenario to account for some weird error
+            Scenario:
+                When I visit the page "/hello-world"
+                Then I should see "Hello world!" on the page
+        """
+        And a context file "tests/SomeContext.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use Behat\Behat\Context\Context;
+        use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
+        use Psr\Container\ContainerInterface;
+        use Symfony\Component\BrowserKit\Client;
+
+        final class SomeContext implements Context {
+            private $client;
+
+            public function __construct(Client $client)
+            {
+                $this->client = $client;
+            }
+
+            /** @When I visit the page :page */
+            public function visitPage(string $page): void
+            {
+                $this->client->request('GET', $page);
+            }
+
+            /** @Then I should see :content on the page */
+            public function shouldSeeContentOnPage(string $content): void
+            {
+                assert(false !== strpos($this->client->getResponse()->getContent(), $content));
+            }
+        }
+        """
+
+    Scenario: Injecting BrowserKit client
+        Given a YAML services file containing:
+            """
+            services:
+                App\Tests\SomeContext:
+                    public: true
+                    arguments:
+                        - '@test.client'
+            """
+        When I run Behat
+        Then it should pass
+
+    Scenario: Autowiring and autoconfiguring BrowserKit client
+        Given a YAML services file containing:
+            """
+            services:
+                _defaults:
+                    autowire: true
+                    autoconfigure: true
+
+                App\Tests\SomeContext: ~
+            """
+        When I run Behat
+        Then it should pass

--- a/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
+++ b/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
@@ -8,6 +8,7 @@ use Behat\Behat\Context\Context;
 use Behat\Mink\Mink;
 use Behat\Mink\Session;
 use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
+use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -27,6 +28,8 @@ final class FriendsOfBehatSymfonyExtensionExtension extends Extension implements
 
     public function process(ContainerBuilder $container): void
     {
+        $this->provideBrowserKitIntegration($container);
+
         foreach ($container->findTaggedServiceIds('fob.context') as $serviceId => $attributes) {
             $serviceDefinition = $container->findDefinition($serviceId);
 
@@ -44,8 +47,21 @@ final class FriendsOfBehatSymfonyExtensionExtension extends Extension implements
         $container->setDefinition('behat.service_container', $behatServiceContainerDefinition);
     }
 
+    private function provideBrowserKitIntegration(ContainerBuilder $container): void
+    {
+        if (!class_exists(Client::class) || !$container->has('test.client')) {
+            return;
+        }
+
+        $container->setAlias(Client::class, 'test.client');
+    }
+
     private function provideMinkIntegration(ContainerBuilder $container): void
     {
+        if (!class_exists(Mink::class)) {
+            return;
+        }
+
         $this->registerMink($container);
         $this->registerMinkDefaultSession($container);
         $this->registerMinkParameters($container);


### PR DESCRIPTION
There's already a service for BrowserKit's client, this PR adds acceptance scenarios and autowires it. The architecture might need some rework after introducing Panther support.