### PR TITLE
Fix referencing context initializers

### DIFF
--- a/features/sanity_checks/context_initializer_instantiation.feature
+++ b/features/sanity_checks/context_initializer_instantiation.feature
@@ -1,0 +1,89 @@
+Feature: instantiation of a context initializer
+  I want container to only keep 1 instance of context initializer
+  (if it's a shared service) so it can work correctly if it's stateful
+
+  Scenario:
+    Given a working Symfony application with SymfonyExtension configured
+    And a Behat configuration containing:
+        """
+        default:
+            extensions:
+                FriendsOfBehat\ServiceContainerExtension:
+                    imports:
+                        - "tests/context_initializer.yml"
+
+            suites:
+                default:
+                    contexts:
+                        - App\Tests\SomeContext
+        """
+    And a Behat services definition file "tests/context_initializer.yml" containing:
+        """
+        services:
+            test.initializer:
+                class: App\Tests\CustomContextInitializer
+                tags: ["context.initializer", "event_dispatcher.subscriber"]
+        """
+    And a Behat service implementation file "tests/CustomContextInitializer.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use Behat\Behat\Context\Context;
+        use Behat\Behat\Context\Initializer\ContextInitializer;
+        use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+        final class CustomContextInitializer implements ContextInitializer, EventSubscriberInterface
+        {
+            public static $counter = 0;
+
+            public function __construct()
+            {
+                ++self::$counter;
+            }
+
+            public function initializeContext(Context $context): void
+            {
+                $context->makeItPass(true);
+            }
+
+            public static function getSubscribedEvents()
+            {
+                return [];
+            }
+        }
+        """
+    And a feature file containing:
+        """
+        Feature:
+            Scenario:
+                Then it should pass
+        """
+    And a context file "tests/SomeContext.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use Behat\Behat\Context\Context;
+
+        final class SomeContext implements Context {
+            private $shouldPass = false;
+
+            public function makeItPass(bool $shouldPass)
+            {
+                $this->shouldPass = $shouldPass;
+            }
+
+            /** @Then it should pass */
+            public function itShouldPass(): void
+            {
+                $actualInitializersCount = CustomContextInitializer::$counter;
+                assert(1 === $actualInitializersCount, "$actualInitializersCount initializers were created");
+                assert($this->shouldPass === true);
+            }
+        }
+        """
+    When I run Behat
+    Then it should pass

--- a/src/ServiceContainer/SymfonyExtension.php
+++ b/src/ServiceContainer/SymfonyExtension.php
@@ -182,7 +182,7 @@ final class SymfonyExtension implements Extension
     {
         $definition = $container->findDefinition('fob_symfony.environment_handler.context_service');
         foreach ($container->findTaggedServiceIds(ContextExtension::INITIALIZER_TAG) as $serviceId => $tags) {
-            $definition->addMethodCall('registerContextInitializer', [$container->getDefinition($serviceId)]);
+            $definition->addMethodCall('registerContextInitializer', [new Reference($serviceId)]);
         }
     }
 


### PR DESCRIPTION
With definition, that has been used instead of reference, container has used to created 2 instances of initializer: one with service id, and one "anonymous", described by spl_object_hash in a container, it broke stateful initializers: in my case initializer was also used to reset state before next scenario/example, and initializing and resetting happened with different instances of initializer.

If the fix and test are OK, let me know if you want me to cherry-pick the fix onto master and created additional pull request for master.