### PR TITLE
Remove support for Symfony 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
     - '7.4'
 
 env:
-    - SYMFONY_VERSION=3.4.*
     - SYMFONY_VERSION=4.4.*
     - SYMFONY_VERSION=5.0.*
 
@@ -33,8 +32,6 @@ install:
     - composer require --dev symfony/framework-bundle:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
     - composer require --dev symfony/process:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
     - composer require --dev symfony/yaml:${SYMFONY_VERSION} --no-update --no-scripts --prefer-dist
-
-    - if [ "$SYMFONY_VERSION" = "5.0.*" ]; then composer require --dev behat/behat:dev-master --no-update --no-scripts --prefer-dist; fi
 
     - composer update --prefer-dist
 

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "require": {
         "php": "^7.1",
         "behat/behat": "^3.6.1",
-        "symfony/dependency-injection": "^3.4|^4.4|^5.0",
-        "symfony/http-kernel": "^3.4|^4.4|^5.0",
-        "symfony/proxy-manager-bridge": "^3.4|^4.4|^5.0"
+        "symfony/dependency-injection": "^4.4|^5.0",
+        "symfony/http-kernel": "^4.4|^5.0",
+        "symfony/proxy-manager-bridge": "^4.4|^5.0"
     },
     "require-dev": {
         "friends-of-behat/mink": "^1.7",
@@ -26,10 +26,10 @@
         "friends-of-behat/service-container-extension": "^1.0",
         "phpstan/phpstan-shim": "^0.11",
         "sylius-labs/coding-standard": "^3.0",
-        "symfony/browser-kit": "^3.4|^4.4|^5.0",
-        "symfony/framework-bundle": "^3.4|^4.4|^5.0",
-        "symfony/process": "^3.4|^4.4|^5.0",
-        "symfony/yaml": "^3.4|^4.4|^5.0"
+        "symfony/browser-kit": "^4.4|^5.0",
+        "symfony/framework-bundle": "^4.4|^5.0",
+        "symfony/process": "^4.4|^5.0",
+        "symfony/yaml": "^4.4|^5.0"
     },
     "conflict": {
         "symplify/package-builder": "^7.2",


### PR DESCRIPTION
If you need Symfony 3.4 support, I'd recommend using `v2.0.*` releases, supporting two major Symfony versions is enough maintenance work 🎉 