### PR TITLE
Fallback to configured environment when no server/env environment is found

### DIFF
--- a/features/configuration/configuring_application_kernel.feature
+++ b/features/configuration/configuring_application_kernel.feature
@@ -81,6 +81,7 @@ Feature: Configuring application kernel
         Feature:
             Scenario:
                 Then the application kernel should have environment "custom"
+                And the server and environment variable "APP_ENV" is "custom"
         """
         When I run Behat
         Then it should pass

--- a/src/ServiceContainer/SymfonyExtension.php
+++ b/src/ServiceContainer/SymfonyExtension.php
@@ -71,7 +71,7 @@ final class SymfonyExtension implements Extension
 
     public function load(ContainerBuilder $container, array $config): void
     {
-        $this->fallbackToTestEnvironment();
+        $this->setupTestEnvironment($config['kernel']['environment'] ?? 'test');
 
         $this->loadBootstrap($this->autodiscoverBootstrap($config['bootstrap']));
 
@@ -182,11 +182,11 @@ final class SymfonyExtension implements Extension
         require_once $bootstrap;
     }
 
-    private function fallbackToTestEnvironment(): void
+    private function setupTestEnvironment(string $fallback): void
     {
-        // If there's no defined server / environment variable with an environment, default to test
+        // If there's no defined server / environment variable with an environment, default to configured fallback
         if (($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) === null) {
-            putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = 'test');
+            putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $fallback);
         }
     }
 


### PR DESCRIPTION
The test environment in our setup at work is not called `test` but `local_test`, and we had a problem where the right dotenv file was not loaded from our bootstrap (`.env` was loaded instead of `.env.local_test`).

After a quick investigation, it appears that `SymfonyExtension` does not use the configured environment but rather fallbacks to hardcoded `test`. This PR fixes that.

I have also renamed the `fallbackToTestEnvironment` method to better reflect its purpose.