### PR TITLE
Missing class for Symfony 5

### DIFF
--- a/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
+++ b/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
@@ -10,7 +10,6 @@ use Behat\Mink\Session;
 use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
 use FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
-use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -79,9 +78,12 @@ final class FriendsOfBehatSymfonyExtensionExtension extends Extension implements
             return;
         }
 
-        foreach ([Client::class, KernelBrowser::class, HttpKernelBrowser::class] as $class) {
-            $container->setAlias($class, 'test.client');
+        if (\class_exists('Symfony\Component\BrowserKit\Client')) {
+            $container->setAlias('Symfony\Component\BrowserKit\Client', 'test.client');
         }
+
+        $container->setAlias(KernelBrowser::class, 'test.client');
+        $container->setAlias(HttpKernelBrowser::class, 'test.client');
     }
 
     private function provideMinkIntegration(ContainerBuilder $container): void

--- a/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
+++ b/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
@@ -10,6 +10,7 @@ use Behat\Mink\Session;
 use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
 use FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -78,8 +79,8 @@ final class FriendsOfBehatSymfonyExtensionExtension extends Extension implements
             return;
         }
 
-        if (\class_exists('Symfony\Component\BrowserKit\Client')) {
-            $container->setAlias('Symfony\Component\BrowserKit\Client', 'test.client');
+        if (class_exists(Client::class)) {
+            $container->setAlias(Client::class, 'test.client');
         }
 
         $container->setAlias(KernelBrowser::class, 'test.client');


### PR DESCRIPTION
Symfony 5 and higher versions not contains Client class.

https://github.com/symfony/browser-kit/tree/5.0