### PR TITLE
Example on how to enable test environment

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -413,3 +413,18 @@ default:
  
     It allows you to force enabling or disabling debug mode. If it is not set, it uses `APP_DEBUG` environment variable 
     if defined or falls back to `true`.
+
+## Enable the kernel environment **test**
+
+To configure the environment used by the kernel (*APP_ENV*) while running scenarios, configure the extension :
+
+```yaml
+# behat.yaml.dist / behat.yaml
+
+default:
+    extensions:
+        FriendsOfBehat\SymfonyExtension:
+            kernel:
+                environment: test
+            bootstrap: tests/bootstrap.php
+```


### PR DESCRIPTION
It is very easy to have failure with the default configuration. In most case, some env variable are not found.
Eg: Uncaught PHP Exception Symfony\Component\DependencyInjection\Exception\EnvNotFoundException: "Environment variable not found: "CORS_ALLOW_ORIGIN"." at /application/vendor/symfony/dependency-injection/EnvVarProcessor.php line 171