### PR TITLE
Add PHP 8.1 compatibility

### DIFF
--- a/src/Mink/MinkParameters.php
+++ b/src/Mink/MinkParameters.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace FriendsOfBehat\SymfonyExtension\Mink;
 
+use ReturnTypeWillChange;
+
 /** @final */
 class MinkParameters implements \Countable, \IteratorAggregate, \ArrayAccess
 {
@@ -25,6 +27,7 @@ class MinkParameters implements \Countable, \IteratorAggregate, \ArrayAccess
         return array_key_exists($offset, $this->minkParameters);
     }
 
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->minkParameters[$offset] ?? null;


### PR DESCRIPTION
Solves these errors on PHP 8.1:

```
Return type of FriendsOfBehat\SymfonyExtension\Mink\MinkParameters::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```