### PR TITLE
Allow Symfony 6

### DIFF
--- a/.github/workflows/tests-upcoming-symfony.yml
+++ b/.github/workflows/tests-upcoming-symfony.yml
@@ -1,0 +1,47 @@
+name: "Test Symfony Dev"
+
+on:
+    push: ~
+    pull_request:
+
+env:
+    fail-fast: true
+
+jobs:
+    tests:
+        runs-on: 'ubuntu-latest'
+        continue-on-error: true
+
+        strategy:
+            matrix:
+                symfony-version: ['5.4.x@dev', '6.0.x@dev']
+
+        steps:
+            -
+                name: 'Checkout code'
+                uses: actions/checkout@v2.3.3
+
+            - 
+                name: 'Install PHP with extensions'
+                uses: shivammathur/setup-php@2.7.0
+                with:
+                    coverage: none
+                    php-version: '8.0'
+                    tools: flex
+
+            -
+                name: Remove dev dependencies not compatible with Symfony Dev
+                if: startsWith(matrix.symfony-version, '6.0')
+                run: composer remove sylius-labs/coding-standard vimeo/psalm --dev --no-update --no-interaction
+
+            - 
+                name: 'Install project dependencies'
+                env:
+                    SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
+                run: |
+                    composer config minimum-stability dev
+                    composer update --no-interaction --prefer-dist --optimize-autoloader
+
+            - 
+                name: 'Run tests'
+                run: composer test || exit 0

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "behat/behat": "^3.6.1",
-        "symfony/dependency-injection": "^4.4 || ^5.1",
-        "symfony/http-kernel": "^4.4 || ^5.1",
-        "symfony/proxy-manager-bridge": "^4.4 || ^5.1"
+        "symfony/dependency-injection": "^4.4 || ^5.1 || ^6.0",
+        "symfony/http-kernel": "^4.4 || ^5.1 || ^6.0",
+        "symfony/proxy-manager-bridge": "^4.4 || ^5.1 || ^6.0"
     },
     "require-dev": {
         "behat/mink-selenium2-driver": "^1.3",
@@ -25,10 +25,10 @@
         "friends-of-behat/page-object-extension": "^0.3.2",
         "friends-of-behat/service-container-extension": "^1.1",
         "sylius-labs/coding-standard": "^3.2",
-        "symfony/browser-kit": "^4.4 || ^5.1",
-        "symfony/framework-bundle": "^4.4 || ^5.1",
-        "symfony/process": "^4.4 || ^5.1",
-        "symfony/yaml": "^4.4 || ^5.1",
+        "symfony/browser-kit": "^4.4 || ^5.1 || ^6.0",
+        "symfony/framework-bundle": "^4.4 || ^5.1 || ^6.0",
+        "symfony/process": "^4.4 || ^5.1 || ^6.0",
+        "symfony/yaml": "^4.4 || ^5.1 || ^6.0",
         "vimeo/psalm": "4.4.1"
     },
     "suggest": {

--- a/tests/Behat/Context/TestContext.php
+++ b/tests/Behat/Context/TestContext.php
@@ -101,6 +101,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as HttpKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 class Kernel extends HttpKernel
 {
@@ -125,9 +126,16 @@ class Kernel extends HttpKernel
         $loader->load(__DIR__ . '/../config/services.yaml');
     }
     
-    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    protected function configureRoutes($routes): void
     {
-        $routes->add('/hello-world', 'App\Controller:helloWorld');
+        if ($routes instanceof RoutingConfigurator) { // available since Symfony 5.1
+            $routes
+                ->add('app_hello', '/hello-world')
+                ->controller('App\Controller::helloWorld')
+            ;
+        } else { // support Symfony 4.4  
+            $routes->add('/hello-world', 'App\Controller:helloWorld');
+        }
     }
 }
 CON


### PR DESCRIPTION
- Allow Symfony 6
- Add CI for upcoming Symfony versions
- Fix tests with Symfony 6

**TODO**
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires friends-of-behat/mink ^1.9 -> satisfiable by friends-of-behat/mink[v1.9.0].
    - friends-of-behat/mink v1.9.0 requires symfony/css-selector ^3.4|^4.4|^5.0 -> found symfony/css-selector[v3.4.0-BETA1, ..., 3.4.x-dev, v4.4.0-BETA1, ..., 4.4.x-dev, v5.0.0-BETA1, ..., 5.4.x-dev] but these were not loaded, likely because it conflicts with another require.
  Problem 2
    - Root composer.json requires friends-of-behat/mink-browserkit-driver ^1.5 -> satisfiable by friends-of-behat/mink-browserkit-driver[v1.5.0].
    - friends-of-behat/mink-browserkit-driver v1.5.0 requires symfony/browser-kit ^4.4|^5.0 -> found symfony/browser-kit[v4.4.0-BETA1, ..., 4.4.x-dev, v5.0.0-BETA1, ..., 5.4.x-dev] but these were not loaded, likely because it conflicts with another require.
  Problem 3
    - Root composer.json requires friends-of-behat/mink-extension ^2.5 -> satisfiable by friends-of-behat/mink-extension[v2.5.0].
    - friends-of-behat/mink-extension v2.5.0 requires symfony/config ^3.4 || ^4.4 || ^5.0 -> found symfony/config[v3.4.0-BETA1, ..., 3.4.x-dev, v4.4.0-BETA1, ..., 4.4.x-dev, v5.0.0-BETA1, ..., 5.4.x-dev] but these were not loaded, likely because it conflicts with another require.
```
- [x] friends-of-behat/mink - https://github.com/FriendsOfBehat/Mink/pull/3
- [ ] friends-of-behat/mink-browserkit-driver
- [ ] friends-of-behat/mink-extension

 