### PR TITLE
Add return type mixed to offsetGet

### DIFF
--- a/src/Mink/MinkParameters.php
+++ b/src/Mink/MinkParameters.php
@@ -27,6 +27,9 @@ class MinkParameters implements \Countable, \IteratorAggregate, \ArrayAccess
         return array_key_exists($offset, $this->minkParameters);
     }
 
+    /**
+     * @return mixed
+     */
     #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {


### PR DESCRIPTION
Turns out that #175 was not enough to make Symfony happy:
```
Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "FriendsOfBehat\SymfonyExtension\Mink\MinkParameters" now to avoid errors or add an explicit @return annotation to suppress this message.
```

The deprecation error triggers on Symfony 5.4 / 6.0. 

@pamil Could you please merge and tag this? Thanks!