### PR TITLE
Switch back to the original `behat/mink-browserkit-driver`

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -284,7 +284,7 @@ isolated driver to use for Symfony application testing.
 1. Require the packages needed for the driver using _Composer_:
 
 ```bash
-composer require --dev friends-of-behat/mink friends-of-behat/mink-extension friends-of-behat/mink-browserkit-driver
+composer require --dev behat/mink friends-of-behat/mink-extension behat/mink-browserkit-driver
 ```
 
 _Those `friends-of-behat` packages are forks of the original ones, adding support for Symfony 5 and dropping support for Symfony <4.4._

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "symfony/proxy-manager-bridge": "^4.4 || ^5.3 || ^6.0"
     },
     "require-dev": {
+        "behat/mink-browserkit-driver": "^2.0",
         "behat/mink-selenium2-driver": "^1.3",
         "friends-of-behat/mink": "^1.9",
-        "friends-of-behat/mink-browserkit-driver": "^1.5",
         "friends-of-behat/mink-extension": "^2.5",
         "friends-of-behat/page-object-extension": "^0.3.2",
         "friends-of-behat/service-container-extension": "^1.1",
@@ -32,8 +32,8 @@
         "vimeo/psalm": "4.15.0"
     },
     "suggest": {
+        "behat/mink-browserkit-driver": "^2.0",
         "friends-of-behat/mink": "^1.9",
-        "friends-of-behat/mink-browserkit-driver": "^1.5",
         "friends-of-behat/mink-extension": "^2.5"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "behat/mink-browserkit-driver": "^2.0",
         "behat/mink-selenium2-driver": "^1.3",
-        "friends-of-behat/mink": "^1.9",
+        "behat/mink": "^1.9",
         "friends-of-behat/mink-extension": "^2.5",
         "friends-of-behat/page-object-extension": "^0.3.2",
         "friends-of-behat/service-container-extension": "^1.1",
@@ -33,7 +33,7 @@
     },
     "suggest": {
         "behat/mink-browserkit-driver": "^2.0",
-        "friends-of-behat/mink": "^1.9",
+        "behat/mink": "^1.9",
         "friends-of-behat/mink-extension": "^2.5"
     },
     "config": {

--- a/src/Driver/Factory/SymfonyDriverFactory.php
+++ b/src/Driver/Factory/SymfonyDriverFactory.php
@@ -42,7 +42,7 @@ final class SymfonyDriverFactory implements DriverFactory
     public function buildDriver(array $config): Definition
     {
         if (!class_exists(BrowserKitDriver::class)) {
-            throw new \RuntimeException('Install "friends-of-behat/mink-browserkit-driver" (drop-in replacement for "behat/mink-browserkit-driver") in order to use the "symfony" driver.');
+            throw new \RuntimeException('Install "behat/mink-browserkit-driver" in order to use the "symfony" driver.');
         }
 
         return new Definition(SymfonyDriver::class, [


### PR DESCRIPTION
This builds upon the suggestion in #187.

If I get it right, `friends-of-behat/mink-browserkit-driver` was a fork of the original `behat/mink-browserkit-driver` at a time where the original repo was lagging behind in terms of PHP and Symfony version support.

It seems the original is now being maintained again, so we should recommend switching back – especially since the FriendsOfBehat version says:

> No updates other than Symfony compatibility will be provided, but this fork might be synchronised with the original repository in the future.

#SymfonyHackday