### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,8 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "behat/behat": "^3.6.1",
-        "symfony/dependency-injection": "^4.4 || ^5.3 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.3 || ^6.0",
-        "symfony/proxy-manager-bridge": "^4.4 || ^5.3 || ^6.0"
+        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
+        "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
         "behat/mink-selenium2-driver": "^1.3",
@@ -25,10 +24,10 @@
         "friends-of-behat/page-object-extension": "^0.3.2",
         "friends-of-behat/service-container-extension": "^1.1",
         "sylius-labs/coding-standard": ">=4.1.1, <=4.2.1",
-        "symfony/browser-kit": "^4.4 || ^5.3 || ^6.0",
-        "symfony/framework-bundle": "^4.4 || ^5.3 || ^6.0",
-        "symfony/process": "^4.4 || ^5.3 || ^6.0",
-        "symfony/yaml": "^4.4 || ^5.3 || ^6.0",
+        "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
+        "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",
+        "symfony/process": "^4.4 || ^5.4 || ^6.0",
+        "symfony/yaml": "^4.4 || ^5.4 || ^6.0",
         "vimeo/psalm": "4.30.0"
     },
     "suggest": {
@@ -37,7 +36,10 @@
         "friends-of-behat/mink-extension": "^2.5"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
 `symfony/proxy-manager-bridge` doesn't seem to be used, and is blocking upgrade to PHP 8.2. Also it's deprecated: https://github.com/symfony/symfony/pull/48484