### PR TITLE
fix: allow to use parameter resolution in configuration for bootstrap key

### DIFF
--- a/features/configuration/loading_configured_bootstrap_file.feature
+++ b/features/configuration/loading_configured_bootstrap_file.feature
@@ -54,3 +54,58 @@ Feature: Loading configured bootstrap file
         """
         When I run Behat
         Then it should pass
+
+    Scenario: Loading configured bootstrap file with parameter resolution
+        Given a working Symfony application with SymfonyExtension configured
+        And a Behat configuration containing:
+        """
+        default:
+            extensions:
+                FriendsOfBehat\SymfonyExtension:
+                    bootstrap: '%paths.base%/custom/bootstrap.php'
+
+            suites:
+                default:
+                    contexts:
+                        - App\Tests\SomeContext
+        """
+        And a boostrap file "custom/bootstrap.php" containing:
+        """
+        <?php
+
+        putenv("CUSTOM_VARIABLE=lol2");
+        $_SERVER['CUSTOM_VARIABLE'] = $_ENV['CUSTOM_VARIABLE'] = 'lol2';
+        """
+        And a context file "tests/SomeContext.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use Behat\Behat\Context\Context;
+
+        final class SomeContext implements Context {
+            private $parameter;
+
+            public function __construct(?string $parameter = null) { $this->parameter = $parameter; }
+
+            /** @Then the passed parameter should be :expected */
+            public function parameterShouldBe(string $expected): void { assert($this->parameter === $expected); }
+        }
+        """
+        And a YAML services file containing:
+        """
+        services:
+            App\Tests\SomeContext:
+                public: true
+                arguments:
+                    - "%env(CUSTOM_VARIABLE)%"
+        """
+        And a feature file containing:
+        """
+        Feature:
+            Scenario:
+                Then the passed parameter should be "lol2"
+        """
+        When I run Behat
+        Then it should pass

--- a/src/ServiceContainer/SymfonyExtension.php
+++ b/src/ServiceContainer/SymfonyExtension.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Parameter;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 
 final class SymfonyExtension implements Extension
@@ -73,7 +74,7 @@ final class SymfonyExtension implements Extension
     {
         $this->setupTestEnvironment($config['kernel']['environment'] ?? 'test');
 
-        $this->loadBootstrap($this->autodiscoverBootstrap($config['bootstrap']));
+        $this->loadBootstrap($this->autodiscoverBootstrap($config['bootstrap'], $container->getParameterBag()));
 
         $this->loadKernel($container, $this->autodiscoverKernelConfiguration($config['kernel']));
         $this->loadDriverKernel($container);
@@ -232,10 +233,10 @@ final class SymfonyExtension implements Extension
     /**
      * @param string|bool|null $bootstrap
      */
-    private function autodiscoverBootstrap($bootstrap): ?string
+    private function autodiscoverBootstrap($bootstrap, ParameterBag $parameterBag): ?string
     {
         if (is_string($bootstrap)) {
-            return $bootstrap;
+            return $parameterBag->resolveString($bootstrap);
         }
 
         if ($bootstrap === false) {
@@ -243,15 +244,16 @@ final class SymfonyExtension implements Extension
         }
 
         $autodiscovered = 0;
+        $basePath = $parameterBag->get('paths.base');
 
-        if (file_exists('config/bootstrap.php')) {
-            $bootstrap = 'config/bootstrap.php';
+        if (file_exists($basePath . '/config/bootstrap.php')) {
+            $bootstrap = $basePath . '/config/bootstrap.php';
 
             ++$autodiscovered;
         }
 
-        if (file_exists('app/autoload.php')) {
-            $bootstrap = 'app/autoload.php';
+        if (file_exists($basePath . '/app/autoload.php')) {
+            $bootstrap = $basePath . '/app/autoload.php';
 
             ++$autodiscovered;
         }


### PR DESCRIPTION


In PhpStorm, I've got an issue with path resolution for the bootstrap file. I don't know why the path in which Behat runs is always the folder `features`. So Behat always fails trying to look for `/project/root/path/features/config/bootstrap.php`.

With this fix, bootstrap file will be resolved based on the base path. Plus, people will be allowed to use the parameter `%paths.base%` to define a custom bootstrap file path. E.g.:

```yaml
default:
  extensions:
    FriendsOfBehat\SymfonyExtension:
      bootstrap: '%paths.base%/custom/bootstrap.php'
```