### PR TITLE
Replace deprecated `Extension` for Symfony 7.1

### DIFF
--- a/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
+++ b/src/Bundle/DependencyInjection/FriendsOfBehatSymfonyExtensionExtension.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 use Symfony\Component\HttpKernel\KernelInterface;
 


### PR DESCRIPTION
# Description
Symfony 7.1 deprecation:

> The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "FriendsOfBehat\SymfonyExtension\Bundle\DependencyInjection\FriendsOfBehatSymfonyExtensionExtension".