### PR TITLE
Add Symfony 8 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
                 include:
                     - php-version: '8.1'
                       symfony-version: '6.4.*'
+                    - php-version: '8.4'
+                      symfony-version: '^8.0.0-BETA-1'
+                      composer-minimum-stability: beta
         steps:
             - name: Checkout
               uses: actions/checkout@v3
@@ -41,6 +44,10 @@ jobs:
             # This works around SYMFONY_REQUIRE currently not working (https://github.com/symfony/flex/issues/946):
             - name: Lock Symfony version
               run: VERSION=${{ matrix.symfony-version }} .github/workflows/lock-symfony-version.sh
+
+            - name: Configure Composer minimum stability
+              if: matrix.composer-minimum-stability != ''
+              run: composer config minimum-stability ${{ matrix.composer-minimum-stability }}
 
             - name: Install dependencies
               run: |

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": "^8.1",
         "behat/behat": "^3.22",
-        "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/http-kernel": "^6.4 || ^7.0"
+        "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "behat/mink-browserkit-driver": "^2.0",
@@ -24,10 +24,10 @@
         "friends-of-behat/page-object-extension": "^0.3.2",
         "friends-of-behat/service-container-extension": "^1.1",
         "sylius-labs/coding-standard": ">=4.1.1, <=4.2.1",
-        "symfony/browser-kit": "^6.4 || ^7.0",
-        "symfony/framework-bundle": "^6.4 || ^7.0",
-        "symfony/process": "^6.4 || ^7.0",
-        "symfony/yaml": "^6.4 || ^7.0",
+        "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",
+        "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+        "symfony/process": "^6.4 || ^7.0 || ^8.0",
+        "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
         "vimeo/psalm": "^6.0"
     },
     "suggest": {


### PR DESCRIPTION
This PR increase version constraints on `symfony/*` packages to allow Symfony 8, which will be released this month
