### PR TITLE
Add Symfony 8 and Behat 4 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
                 include:
                     - php-version: '8.1'
                       symfony-version: '6.4.*'
+                    - php-version: '8.4'
+                      symfony-version: '8.0.*'
+                      behat-version: '4.x-dev'
         steps:
             - name: Checkout
               uses: actions/checkout@v3
@@ -41,6 +44,14 @@ jobs:
             # This works around SYMFONY_REQUIRE currently not working (https://github.com/symfony/flex/issues/946):
             - name: Lock Symfony version
               run: VERSION=${{ matrix.symfony-version }} .github/workflows/lock-symfony-version.sh
+
+            - name: Set minimum stability for dev packages
+              if: matrix.behat-version == '4.x-dev'
+              run: composer config minimum-stability dev
+
+            - name: Install Behat 4.x-dev
+              if: matrix.behat-version == '4.x-dev'
+              run: composer require behat/behat:${{ matrix.behat-version }} --no-update
 
             - name: Install dependencies
               run: |

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": "^8.1",
-        "behat/behat": "^3.22",
-        "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/http-kernel": "^6.4 || ^7.0"
+        "behat/behat": "^3.22 || ^4.0",
+        "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "behat/mink-browserkit-driver": "^2.0",
@@ -24,10 +24,10 @@
         "friends-of-behat/page-object-extension": "^0.3.2",
         "friends-of-behat/service-container-extension": "^1.1",
         "sylius-labs/coding-standard": ">=4.1.1, <=4.2.1",
-        "symfony/browser-kit": "^6.4 || ^7.0",
-        "symfony/framework-bundle": "^6.4 || ^7.0",
-        "symfony/process": "^6.4 || ^7.0",
-        "symfony/yaml": "^6.4 || ^7.0",
+        "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",
+        "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+        "symfony/process": "^6.4 || ^7.0 || ^8.0",
+        "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
         "vimeo/psalm": "^6.0"
     },
     "suggest": {


### PR DESCRIPTION
## Summary

This PR adds support for Symfony 8 and Behat 4.

The extension code already has the required return types on `process()` methods, making it compatible with both Behat 3.x and 4.x interfaces (as noted by @mpdude in #218).

## Changes

- Update `behat/behat` constraint to `^3.22 || ^4.0`
- Update `symfony/*` dependencies to include `^8.0`
- Add CI matrix entry for Symfony 8.0 with Behat 4.x-dev

## Notes

- Symfony 8 requires Behat 4.x-dev as Behat 3.x doesn't declare Symfony 8 compatibility
- This PR builds on the discussion in #218, incorporating @mpdude's insight that the extension is already code-compatible

## Related

- Behat/Behat#1687 (Symfony 8 support merged into Behat 4.x)
- #218 (Previous Symfony 8 support PR, still in draft)