### PR TITLE
Allow Symfony 8 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": "^8.3",
         "behat/behat": "^3.22",
-        "symfony/dependency-injection": "^7.4",
-        "symfony/http-kernel": "^7.4"
+        "symfony/dependency-injection": "^7.4 || ^8.0",
+        "symfony/http-kernel": "^7.4 || ^8.0"
     },
     "require-dev": {
         "behat/mink-browserkit-driver": "^2.0",
@@ -24,10 +24,10 @@
         "friends-of-behat/page-object-extension": "^0.3.2",
         "friends-of-behat/service-container-extension": "^1.1",
         "sylius-labs/coding-standard": ">=4.1.1, <=4.2.1",
-        "symfony/browser-kit": "^7.4",
-        "symfony/framework-bundle": "^7.4",
-        "symfony/process": "^7.4",
-        "symfony/yaml": "^7.4",
+        "symfony/browser-kit": "^7.4 || ^8.0",
+        "symfony/framework-bundle": "^7.4 || ^8.0",
+        "symfony/process": "^7.4 || ^8.0",
+        "symfony/yaml": "^7.4 || ^8.0",
         "vimeo/psalm": "^6.0"
     },
     "suggest": {


### PR DESCRIPTION
Add `^8.0` to all Symfony dependency constraints (`require` and `require-dev`).

The `BrowserKit\Client` import on line 13 is already guarded by `class_exists()` so it won't break on Symfony 8 where the class no longer exists.

This unblocks projects upgrading to Symfony 8 (e.g. Sylius — see https://github.com/Sylius/Sylius/issues/18760).