### PR TITLE
Fix CI: update matrix to Symfony 7.4, fix Psalm MissingTemplateParam

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,7 @@ jobs:
                     - '8.3'
                     - '8.4'
                 symfony-version:
-                    - '7.0.*'
-                    - '7.3.*'
+                    - '7.4.*'
                 include:
                     - php-version: '8.1'
                       symfony-version: '6.4.*'

--- a/psalm.xml
+++ b/psalm.xml
@@ -71,5 +71,11 @@
                 <file name="src/ServiceContainer/SymfonyExtension.php" />
             </errorLevel>
         </UnusedForeachValue>
+
+        <UnusedMethodCall>
+            <errorLevel type="suppress">
+                <file name="src/ServiceContainer/SymfonyExtension.php" />
+            </errorLevel>
+        </UnusedMethodCall>
     </issueHandlers>
 </psalm>

--- a/src/Driver/SymfonyDriver.php
+++ b/src/Driver/SymfonyDriver.php
@@ -6,8 +6,13 @@ namespace FriendsOfBehat\SymfonyExtension\Driver;
 
 use Behat\Mink\Driver\BrowserKitDriver;
 use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+/**
+ * @extends BrowserKitDriver<Request, Response>
+ */
 final class SymfonyDriver extends BrowserKitDriver
 {
     /** @var KernelInterface */


### PR DESCRIPTION
## Summary
- Replace EOL Symfony versions (7.0, 7.3) in CI matrix with 7.4 (current LTS) — all 7.0.x and 7.3.x releases are blocked by Composer due to unpatched security advisories in `symfony/yaml` and `symfony/process`
- Add `@extends BrowserKitDriver<Request, Response>` to `SymfonyDriver` to satisfy the template params added in `behat/mink-browserkit-driver` v2.x
- Suppress `UnusedMethodCall` in `SymfonyExtension.php` (standard Symfony config builder chain pattern, spurious on newer PHP/Psalm versions)

🤖 Generated with [Claude Code](https://claude.ai/code)