### PR TITLE
Drop support for PHP <8.3 and Symfony <7.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,10 @@ jobs:
             fail-fast: false
             matrix:
                 php-version:
-                    - '8.2'
                     - '8.3'
                     - '8.4'
                 symfony-version:
                     - '7.4.*'
-                include:
-                    - php-version: '8.1'
-                      symfony-version: '6.4.*'
         steps:
             - name: Checkout
               uses: actions/checkout@v3
@@ -63,7 +59,7 @@ jobs:
               with:
                   coverage: none
                   ini-values: "memory_limit=-1, zend.assertions=1"
-                  php-version: 8.1
+                  php-version: 8.3
                   tools: composer:v2, flex
 
             - name: Install dependencies
@@ -87,7 +83,7 @@ jobs:
               with:
                   coverage: none
                   ini-values: "memory_limit=-1, zend.assertions=1"
-                  php-version: 8.2
+                  php-version: 8.3
                   tools: composer:v2, flex
 
             - name: Validate composer.json
@@ -106,7 +102,7 @@ jobs:
               with:
                   coverage: none
                   ini-values: "memory_limit=-1, zend.assertions=1"
-                  php-version: 8.2
+                  php-version: 8.3
                   tools: composer:v2, flex
 
             - name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "behat/behat": "^3.22",
-        "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/http-kernel": "^6.4 || ^7.0"
+        "symfony/dependency-injection": "^7.4",
+        "symfony/http-kernel": "^7.4"
     },
     "require-dev": {
         "behat/mink-browserkit-driver": "^2.0",
@@ -24,10 +24,10 @@
         "friends-of-behat/page-object-extension": "^0.3.2",
         "friends-of-behat/service-container-extension": "^1.1",
         "sylius-labs/coding-standard": ">=4.1.1, <=4.2.1",
-        "symfony/browser-kit": "^6.4 || ^7.0",
-        "symfony/framework-bundle": "^6.4 || ^7.0",
-        "symfony/process": "^6.4 || ^7.0",
-        "symfony/yaml": "^6.4 || ^7.0",
+        "symfony/browser-kit": "^7.4",
+        "symfony/framework-bundle": "^7.4",
+        "symfony/process": "^7.4",
+        "symfony/yaml": "^7.4",
         "vimeo/psalm": "^6.0"
     },
     "suggest": {


### PR DESCRIPTION
## Summary
- Bump `php` requirement to `^8.3` (PHP 8.1 EOL Nov 2024, PHP 8.2 active support ended Dec 2024)
- Bump all `symfony/*` constraints to `^7.4` (current LTS), dropping Symfony 6.4
- Update CI matrix accordingly: PHP 8.3 + 8.4 × Symfony 7.4, removing the separate 8.1 + 6.4 include entry
- Update hardcoded PHP versions in Psalm/validate/coding-standards jobs to 8.3

🤖 Generated with [Claude Code](https://claude.ai/code)