### PR TITLE
Restrict push trigger to master to avoid duplicate CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
     push:
+        branches:
+            - master
     pull_request:
     release:
         types: [created]


### PR DESCRIPTION
## Summary
- Limit the `push` workflow trigger to the `master` branch
- Branch pushes with an open PR were triggering both `push` and `pull_request` workflows, wasting CI minutes
- Now branch pushes only trigger via `pull_request`; `push` only fires on merges to master

🤖 Generated with [Claude Code](https://claude.ai/code)