### PR TITLE
Add PHP 8.5 to CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
                 php-version:
                     - '8.3'
                     - '8.4'
+                    - '8.5'
                 symfony-version:
                     - '7.4.*'
         steps:


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to the test matrix alongside 8.3 and 8.4

🤖 Generated with [Claude Code](https://claude.ai/code)