### PR TITLE
Add Symfony 8 and PHP 8.5 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,46 @@ jobs:
             - name: Run tests
               run: composer test
 
+    symfony8-php85-consumer-install:
+        name: Symfony 8 + PHP 8.5 consumer install
+        runs-on: ubuntu-22.04
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  coverage: none
+                  ini-values: "memory_limit=-1"
+                  php-version: '8.5'
+                  tools: composer:v2
+
+            - name: Verify installability in a Symfony 8 consumer project
+              run: |
+                  mkdir /tmp/fob-symfony8-consumer
+                  cat > /tmp/fob-symfony8-consumer/composer.json <<'JSON'
+                  {
+                      "name": "friends-of-behat/symfony8-consumer-probe",
+                      "type": "project",
+                      "minimum-stability": "dev",
+                      "prefer-stable": true,
+                      "repositories": [
+                          {"type": "path", "url": "${{ github.workspace }}", "options": {"symlink": false}}
+                      ],
+                      "require-dev": {
+                          "behat/behat": "4.x-dev",
+                          "friends-of-behat/symfony-extension": "*",
+                          "symfony/framework-bundle": "^8.0",
+                          "symfony/yaml": "^8.0"
+                      },
+                      "config": {
+                          "sort-packages": true
+                      }
+                  }
+                  JSON
+                  composer update --working-dir=/tmp/fob-symfony8-consumer --no-interaction --no-plugins --prefer-dist --no-progress
+
     psalm:
         name: Run Psalm
         runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# CHANGELOG FOR `2.3.x`
+
+## v2.3.0 (unreleased)
+
+#### TL;DR
+
+- **Added installability support for Symfony 8 and PHP 8.5**.
+
+#### Details
+
+- Allow `symfony/dependency-injection` and `symfony/http-kernel` `^8.0`.
+- Allow Behat `^4.0`, which is required by Symfony 8 because Behat 3.x only supports Symfony components up to 7.x.
+- Keep Symfony 7.4 / Behat 3.31 compatibility and add a CI consumer-install probe for Symfony 8 on PHP 8.5.
+
 # CHANGELOG FOR `2.1.x`
 
 ## v2.2.0 (2021-02-04)

--- a/composer.json
+++ b/composer.json
@@ -11,23 +11,23 @@
         }
     ],
     "require": {
-        "php": "^8.3",
-        "behat/behat": "^3.22",
-        "symfony/dependency-injection": "^7.4",
-        "symfony/http-kernel": "^7.4"
+        "php": ">=8.3 <8.6",
+        "behat/behat": "^3.31 || ^4.0",
+        "symfony/dependency-injection": "^7.4 || ^8.0",
+        "symfony/http-kernel": "^7.4 || ^8.0"
     },
     "require-dev": {
         "behat/mink-browserkit-driver": "^2.0",
         "behat/mink-selenium2-driver": "^1.3",
         "behat/mink": "^1.9",
         "friends-of-behat/mink-extension": "^2.5",
-        "friends-of-behat/page-object-extension": "^0.3.2",
-        "friends-of-behat/service-container-extension": "^1.1",
+        "friends-of-behat/page-object-extension": "^0.4",
+        "friends-of-behat/service-container-extension": "^2.0",
         "sylius-labs/coding-standard": ">=4.1.1, <=4.2.1",
-        "symfony/browser-kit": "^7.4",
-        "symfony/framework-bundle": "^7.4",
-        "symfony/process": "^7.4",
-        "symfony/yaml": "^7.4",
+        "symfony/browser-kit": "^7.4 || ^8.0",
+        "symfony/framework-bundle": "^7.4 || ^8.0",
+        "symfony/process": "^7.4 || ^8.0",
+        "symfony/yaml": "^7.4 || ^8.0",
         "vimeo/psalm": "^6.0"
     },
     "suggest": {
@@ -43,7 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2-dev"
+            "dev-master": "2.3-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
## Summary

- Allow PHP `>=8.3 <8.6`, including PHP 8.5
- Allow Symfony 8 components for the extension runtime and dev/test dependencies
- Allow Behat 4 while keeping Behat 3.31 support
- Add a CI consumer-install probe for Symfony 8 + PHP 8.5 dependency resolution
- Document the compatibility work in the changelog

## Companion PR

This needs the MinkExtension Behat 4 constraint relaxation as well:

- https://github.com/FriendsOfBehat/MinkExtension/pull/53

Without that companion change, Symfony 8 consumers that also use MinkExtension can hit dependency resolution conflicts because Behat 3 does not allow Symfony 8 components.

## Validation

Run locally with PHP 8.5:

- `php8.5 /home/veyra/bin/composer validate --strict`
- `php8.5 /home/veyra/bin/composer update --prefer-dist --no-progress --no-plugins`
- `php8.5 vendor/bin/behat -f progress --strict --no-interaction --colors`

Result:

- Composer validation passed
- 64 scenarios / 492 steps passed

I also verified a clean Symfony 8 consumer project on PHP 8.5 with:

- `symfony/framework-bundle` 8.1
- `symfony/browser-kit` 8.1
- `behat/behat` 4.x-dev
- this SymfonyExtension branch
- the companion MinkExtension branch

Result:

- Composer resolved the Symfony 8 / PHP 8.5 dependency set
- A real Symfony kernel booted through SymfonyExtension
- A Behat context received `KernelBrowser` from Symfony's container
- 1 scenario / 1 step passed

## Notes

This PR intentionally keeps the code change minimal: it only updates package compatibility constraints, changelog, and CI coverage. It does not add compatibility shims for Behat 4 test-suite syntax because step/config discovery belongs to Behat itself.

Prepared with help from Veyra, Badr HAKKARI's Hermes agent.
