### PR TITLE
feat: behat 4.x compatibility

### DIFF
--- a/behat.dist.php
+++ b/behat.dist.php
@@ -1,0 +1,15 @@
+<?php
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+use Tests\Behat\Context\TestContext;
+
+return (new Config())
+    ->withProfile(
+        (new Profile('default'))
+            ->withSuite(
+                (new Suite('default'))
+                    ->withContexts(TestContext::class)
+            )
+    );

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,5 +1,0 @@
-default:
-    suites:
-        default:
-            contexts:
-                - Tests\Behat\Context\TestContext

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "behat/behat": "^3.22",
+        "behat/behat": "v4.0.0-alpha1 as 3.32.0",
         "symfony/dependency-injection": "^7.4",
         "symfony/http-kernel": "^7.4"
     },
@@ -20,7 +20,7 @@
         "behat/mink-browserkit-driver": "^2.0",
         "behat/mink-selenium2-driver": "^1.3",
         "behat/mink": "^1.9",
-        "friends-of-behat/mink-extension": "^2.5",
+        "friends-of-behat/mink-extension": "dev-master as 2.7.5",
         "friends-of-behat/page-object-extension": "^0.3.2",
         "friends-of-behat/service-container-extension": "^1.1",
         "sylius-labs/coding-standard": ">=4.1.1, <=4.2.1",

--- a/features/browserkit_integration/browserkit_integration.feature
+++ b/features/browserkit_integration/browserkit_integration.feature
@@ -4,11 +4,16 @@ Feature: BrowserKit integration
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -39,6 +44,8 @@ Feature: BrowserKit integration
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
+        use Behat\Step\When;
         use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
         use Psr\Container\ContainerInterface;
         use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -52,13 +59,13 @@ Feature: BrowserKit integration
                 $this->client = $client;
             }
 
-            /** @When I visit the page :page */
+            #[When('I visit the page :page')]
             public function visitPage(string $page): void
             {
                 $this->client->request('GET', $page);
             }
 
-            /** @Then I should see :content on the page */
+            #[Then('I should see :content on the page')]
             public function shouldSeeContentOnPage(string $content): void
             {
                 assert(false !== strpos($this->client->getResponse()->getContent(), $content));
@@ -85,6 +92,8 @@ Feature: BrowserKit integration
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
+        use Behat\Step\When;
         use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
         use Psr\Container\ContainerInterface;
         use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -98,13 +107,13 @@ Feature: BrowserKit integration
                 $this->client = $client;
             }
 
-            /** @When I visit the page :page */
+            #[When('I visit the page :page')]
             public function visitPage(string $page): void
             {
                 $this->client->request('GET', $page);
             }
 
-            /** @Then I should see :content on the page */
+            #[Then('I should see :content on the page')]
             public function shouldSeeContentOnPage(string $content): void
             {
                 assert(false !== strpos($this->client->getResponse()->getContent(), $content));
@@ -131,6 +140,8 @@ Feature: BrowserKit integration
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
+        use Behat\Step\When;
         use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
         use Psr\Container\ContainerInterface;
         use Symfony\Component\HttpKernel\HttpKernelBrowser;
@@ -144,13 +155,13 @@ Feature: BrowserKit integration
                 $this->client = $client;
             }
 
-            /** @When I visit the page :page */
+            #[When('I visit the page :page')]
             public function visitPage(string $page): void
             {
                 $this->client->request('GET', $page);
             }
 
-            /** @Then I should see :content on the page */
+            #[Then('I should see :content on the page')]
             public function shouldSeeContentOnPage(string $content): void
             {
                 assert(false !== strpos($this->client->getResponse()->getContent(), $content));

--- a/features/configuration/autodiscovering_application_kernel.feature
+++ b/features/configuration/autodiscovering_application_kernel.feature
@@ -10,14 +10,21 @@ Feature: Autodiscovering the application kernel
         """
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension: ~
+        <?php
 
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension::class
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a context file "tests/SomeContext.php" containing:
         """
@@ -26,13 +33,14 @@ Feature: Autodiscovering the application kernel
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             private $service;
 
             public function __construct($service = null) { $this->service = $service; }
 
-            /** @Then the passed service should be an instance of :expected */
+            #[Then('the passed service should be an instance of :expected')]
             public function serviceShouldBe(string $expected): void
             {
                 assert(is_object($this->service));

--- a/features/configuration/autodiscovering_bootstrap_file.feature
+++ b/features/configuration/autodiscovering_bootstrap_file.feature
@@ -4,11 +4,16 @@ Feature: Autodiscovering bootstrap file
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a context file "tests/SomeContext.php" containing:
         """
@@ -17,13 +22,14 @@ Feature: Autodiscovering bootstrap file
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             private $parameter;
 
             public function __construct(?string $parameter = null) { $this->parameter = $parameter; }
 
-            /** @Then the passed parameter should be :expected */
+            #[Then('the passed parameter should be :expected')]
             public function parameterShouldBe(string $expected): void { assert($this->parameter === $expected); }
         }
         """
@@ -92,10 +98,20 @@ Feature: Autodiscovering bootstrap file
         """
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    bootstrap: false
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                        (new \Behat\Config\Extension(
+                            'FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension',
+                            [
+                                'bootstrap' => false
+                            ]
+                        ))
+                    )
+            );
         """
         When I run Behat
         Then it should fail with "Symfony\Component\DependencyInjection\Exception\EnvNotFoundException"

--- a/features/configuration/configuring_application_kernel.feature
+++ b/features/configuration/configuring_application_kernel.feature
@@ -4,11 +4,16 @@ Feature: Configuring application kernel
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a context file "tests/SomeContext.php" containing:
         """
@@ -17,6 +22,7 @@ Feature: Configuring application kernel
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
         use Symfony\Component\HttpKernel\KernelInterface;
 
         final class SomeContext implements Context {
@@ -24,10 +30,10 @@ Feature: Configuring application kernel
 
             public function __construct(KernelInterface $kernel) { $this->kernel = $kernel; }
 
-            /** @Then the application kernel should have environment :environment */
+            #[Then('the application kernel should have environment :environment')]
             public function kernelEnvironmentShouldBe(string $environment): void { assert($this->kernel->getEnvironment() === $environment); }
 
-            /** @Then the application kernel should have debug :state*/
+            #[Then('the application kernel should have debug :state')]
             public function kernelDebugShouldBe(string $state): void
             {
                 $map = ['enabled' => true, 'disabled' => false];
@@ -37,7 +43,7 @@ Feature: Configuring application kernel
                 assert($this->kernel->isDebug() === $map[$state]);
             }
 
-            /** @Then the server and environment variable :variable is :value */
+            #[Then('the server and environment variable :variable is :value')]
             public function environmentVariableIs(string $variable, string $value): void
             {
                 assert($_SERVER[$variable] === $value);
@@ -70,11 +76,22 @@ Feature: Configuring application kernel
     Scenario: Using environment based on Behat configuration
         Given a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    kernel:
-                        environment: custom
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                        (new \Behat\Config\Extension(
+                            'FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension',
+                            [
+                                'kernel' => [
+                                    'environment' => 'custom'
+                                ]
+                            ]
+                        ))
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -129,11 +146,22 @@ Feature: Configuring application kernel
         """
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    kernel:
-                        environment: custom_conf
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                        (new \Behat\Config\Extension(
+                            'FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension',
+                            [
+                                'kernel' => [
+                                    'environment' => 'custom_conf'
+                                ]
+                            ]
+                        ))
+                    )
+            );
         """
         And a server variable "APP_ENV" set to "custom_ser"
         And an environment variable "APP_ENV" set to "custom_env"
@@ -149,10 +177,20 @@ Feature: Configuring application kernel
         """
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    bootstrap: config/bootstrap.php
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                        (new \Behat\Config\Extension(
+                            'FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension',
+                            [
+                                'bootstrap' => 'config/bootstrap.php'
+                            ]
+                        ))
+                    )
+            );
         """
         And a bootstrap file "config/bootstrap.php" containing:
         """
@@ -166,11 +204,22 @@ Feature: Configuring application kernel
     Scenario: Using debug based on Behat configuration
         Given a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    kernel:
-                        debug: false
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                        (new \Behat\Config\Extension(
+                            'FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension',
+                            [
+                                'kernel' => [
+                                    'debug' => false
+                                ]
+                            ]
+                        ))
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -224,11 +273,22 @@ Feature: Configuring application kernel
         """
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    kernel:
-                        debug: false
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                        (new \Behat\Config\Extension(
+                            'FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension',
+                            [
+                                'kernel' => [
+                                    'debug' => false
+                                ]
+                            ]
+                        ))
+                    )
+            );
         """
         And a server variable "APP_DEBUG" set to "1"
         And an environment variable "APP_DEBUG" set to "1"
@@ -244,10 +304,20 @@ Feature: Configuring application kernel
         """
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    bootstrap: config/bootstrap.php
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                        (new \Behat\Config\Extension(
+                            'FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension',
+                            [
+                                'bootstrap' => 'config/bootstrap.php'
+                            ]
+                        ))
+                    )
+            );
         """
         And a bootstrap file "config/bootstrap.php" containing:
         """

--- a/features/configuration/loading_configured_application_kernel.feature
+++ b/features/configuration/loading_configured_application_kernel.feature
@@ -10,11 +10,16 @@ Feature: Loading configured application kernel
         """
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a context file "tests/SomeContext.php" containing:
         """
@@ -23,13 +28,14 @@ Feature: Loading configured application kernel
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             private $service;
 
             public function __construct($service = null) { $this->service = $service; }
 
-            /** @Then the passed service should be an instance of :expected */
+            #[Then('the passed service should be an instance of :expected')]
             public function serviceShouldBe(string $expected): void
             {
                 assert(is_object($this->service));
@@ -49,11 +55,22 @@ Feature: Loading configured application kernel
     Scenario: Loading kernel by its classname
         Given a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    kernel:
-                        class: App\Custom\Kernel
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                        (new \Behat\Config\Extension(
+                            'FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension',
+                            [
+                                'kernel' => [
+                                    'class' => 'App\Custom\Kernel'
+                                ]
+                            ]
+                        ))
+                    )
+            );
         """
         And a kernel file "src/Custom/Kernel.php" containing:
         """
@@ -98,12 +115,23 @@ Feature: Loading configured application kernel
     Scenario: Loading kernel from custom path
         Given a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    kernel:
-                        path: app/Nested/Kernel.php
-                        class: AppKernel
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                        (new \Behat\Config\Extension(
+                            'FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension',
+                            [
+                                'kernel' => [
+                                    'class' => 'AppKernel',
+                                    'path' => 'app/Nested/Kernel.php'
+                                ]
+                            ]
+                        ))
+                    )
+            );
         """
         And a kernel file "app/Nested/Kernel.php" containing:
         """

--- a/features/configuration/loading_configured_bootstrap_file.feature
+++ b/features/configuration/loading_configured_bootstrap_file.feature
@@ -4,15 +4,22 @@ Feature: Loading configured bootstrap file
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    bootstrap: custom/bootstrap.php
+        <?php
 
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension::class,
+                        ['bootstrap' => 'custom/bootstrap.php']
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a boostrap file "custom/bootstrap.php" containing:
         """
@@ -28,13 +35,14 @@ Feature: Loading configured bootstrap file
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             private $parameter;
 
             public function __construct(?string $parameter = null) { $this->parameter = $parameter; }
 
-            /** @Then the passed parameter should be :expected */
+            #[Then('the passed parameter should be :expected')]
             public function parameterShouldBe(string $expected): void { assert($this->parameter === $expected); }
         }
         """
@@ -59,15 +67,22 @@ Feature: Loading configured bootstrap file
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\SymfonyExtension:
-                    bootstrap: '%paths.base%/custom/bootstrap.php'
+        <?php
 
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension::class,
+                        ['bootstrap' => '%paths.base%/custom/bootstrap.php']
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a boostrap file "custom/bootstrap.php" containing:
         """
@@ -83,13 +98,14 @@ Feature: Loading configured bootstrap file
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             private $parameter;
 
             public function __construct(?string $parameter = null) { $this->parameter = $parameter; }
 
-            /** @Then the passed parameter should be :expected */
+            #[Then('the passed parameter should be :expected')]
             public function parameterShouldBe(string $expected): void { assert($this->parameter === $expected); }
         }
         """

--- a/features/dependency_injection/autowiring_contexts.feature
+++ b/features/dependency_injection/autowiring_contexts.feature
@@ -4,11 +4,16 @@ Feature: Autowiring contexts
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
 
     Scenario: Autowiring a context with a service
@@ -25,6 +30,7 @@ Feature: Autowiring contexts
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
         use Psr\Container\ContainerInterface;
 
         final class SomeContext implements Context {
@@ -32,7 +38,7 @@ Feature: Autowiring contexts
 
             public function __construct(?ContainerInterface $container = null) { $this->container = $container; }
 
-            /** @Then the container should be passed */
+            #[Then('the container should be passed')]
             public function containerShouldBePassed(): void
             {
                 assert(is_object($this->container));
@@ -70,13 +76,14 @@ Feature: Autowiring contexts
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             private $argument;
 
             public function __construct(?string $argument = null) { $this->argument = $argument; }
 
-            /** @Then the passed argument should be :expected */
+            #[Then('the passed argument should be :expected')]
             public function passedArgumentShouldBe(string $expected): void { assert($this->argument === $expected); }
         }
         """
@@ -108,6 +115,7 @@ Feature: Autowiring contexts
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
         use Psr\Container\ContainerInterface;
 
         final class SomeContext implements Context {
@@ -115,7 +123,7 @@ Feature: Autowiring contexts
 
             public function __construct(?ContainerInterface $container = null) { $this->container = $container; }
 
-            /** @Then the container should be passed */
+            #[Then('the container should be passed')]
             public function containerShouldBePassed(): void
             {
                 assert(is_object($this->container));
@@ -156,6 +164,7 @@ Feature: Autowiring contexts
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
         use Symfony\Component\BrowserKit\AbstractBrowser;
 
         final class SomeContext implements Context
@@ -164,7 +173,7 @@ Feature: Autowiring contexts
 
             public function __construct(AbstractBrowser $client) { $this->client = $client; }
 
-            /** @Then the client should be passed */
+            #[Then('the client should be passed')]
             public function clientShouldBePassed(): void
             {
                 assert(is_object($this->client));

--- a/features/dependency_injection/injecting_parameters_into_context.feature
+++ b/features/dependency_injection/injecting_parameters_into_context.feature
@@ -4,11 +4,16 @@ Feature: Injecting parameters into context
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -23,13 +28,14 @@ Feature: Injecting parameters into context
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             private $parameter;
 
             public function __construct(?string $parameter = null) { $this->parameter = $parameter; }
 
-            /** @Then the passed parameter should be :expected */
+            #[Then('the passed parameter should be :expected')]
             public function parameterShouldBe(string $expected): void { assert($this->parameter === $expected); }
         }
         """

--- a/features/dependency_injection/injecting_services_into_context.feature
+++ b/features/dependency_injection/injecting_services_into_context.feature
@@ -4,11 +4,16 @@ Feature: Injecting services into context
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -23,13 +28,14 @@ Feature: Injecting services into context
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             private $service;
 
             public function __construct($service = null) { $this->service = $service; }
 
-            /** @Then the passed service should be an instance of :expected */
+            #[Then('the passed service should be an instance of :expected')]
             public function serviceShouldBe(string $expected): void
             {
                 assert(is_object($this->service));

--- a/features/dependency_injection/using_context_by_its_service_id.feature
+++ b/features/dependency_injection/using_context_by_its_service_id.feature
@@ -4,11 +4,16 @@ Feature: Using context by its service ID
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - behat.context.some_context
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('behat.context.some_context')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -23,9 +28,10 @@ Feature: Using context by its service ID
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
-            /** @Then it should pass */
+            #[Then('it should pass')]
             public function shouldPass(): void
             {
             }

--- a/features/fob_page_object_integration/fob_page_object_integration.feature
+++ b/features/fob_page_object_integration/fob_page_object_integration.feature
@@ -4,19 +4,28 @@ Feature: FriendsOfBehat/PageObjectExtension integration
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                Behat\MinkExtension:
-                    base_url: "http://localhost:8080/"
-                    default_session: symfony
-                    sessions:
-                        symfony:
-                            symfony: ~
+        <?php
 
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \Behat\MinkExtension\ServiceContainer\MinkExtension::class,
+                        [
+                            'base_url' => 'http://localhost:8080/',
+                            'default_session' => 'symfony',
+                            'sessions' => [
+                                ['name' => 'symfony', 'symfony' => []]
+                            ]
+                        ]
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -32,6 +41,8 @@ Feature: FriendsOfBehat/PageObjectExtension integration
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
+        use Behat\Step\When;
 
         final class SomeContext implements Context {
             private $homepage;
@@ -41,13 +52,13 @@ Feature: FriendsOfBehat/PageObjectExtension integration
                 $this->homepage = $homepage;
             }
 
-            /** @When I visit the homepage */
+            #[When('I visit the homepage')]
             public function visitPage(): void
             {
                 $this->homepage->open();
             }
 
-            /** @Then I should see :content on the page */
+            #[Then('I should see :content on the page')]
             public function shouldSeeContentOnPage(string $content): void
             {
                 assert(false !== strpos($this->homepage->getContent(), $content));

--- a/features/mink_integration/accessing_drivers_service_container.feature
+++ b/features/mink_integration/accessing_drivers_service_container.feature
@@ -4,18 +4,28 @@ Feature: Accessing driver's service container
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                Behat\MinkExtension:
-                    base_url: "http://localhost:8080/"
-                    default_session: symfony
-                    sessions:
-                        symfony:
-                            symfony: ~
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \Behat\MinkExtension\ServiceContainer\MinkExtension::class,
+                        [
+                            'base_url' => 'http://localhost:8080/',
+                            'default_session' => 'symfony',
+                            'sessions' => [
+                                ['name' => 'symfony', 'symfony' => []]
+                            ]
+                        ]
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -33,6 +43,9 @@ Feature: Accessing driver's service container
 
         use App\Counter;
         use Behat\Behat\Context\Context;
+        use Behat\Step\Given;
+        use Behat\Step\Then;
+        use Behat\Step\When;
         use Behat\Mink\Mink;
         use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -46,19 +59,19 @@ Feature: Accessing driver's service container
                 $this->driverContainer = $driverContainer;
             }
 
-            /** @Given the counter service is zeroed */
+            #[Given('the counter service is zeroed')]
             public function counterServiceIsZeroed(): void
             {
                 assert(0 === $this->getCounterService()->get());
             }
 
-            /** @When I visit the page :page */
+            #[When('I visit the page :page')]
             public function visitPage(string $page): void
             {
                 $this->mink->getSession()->visit($page);
             }
 
-            /** @Then the counter service should return :number */
+            #[Then('the counter service should return :number')]
             public function counterServiceShouldReturn(int $number): void
             {
                 assert($number === $this->getCounterService()->get());

--- a/features/mink_integration/mink_context_integration.feature
+++ b/features/mink_integration/mink_context_integration.feature
@@ -4,19 +4,28 @@ Feature: Mink context integration
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                Behat\MinkExtension:
-                    base_url: "http://localhost:8080/"
-                    default_session: symfony
-                    sessions:
-                        symfony:
-                            symfony: ~
+        <?php
 
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \Behat\MinkExtension\ServiceContainer\MinkExtension::class,
+                        [
+                            'base_url' => 'http://localhost:8080/',
+                            'default_session' => 'symfony',
+                            'sessions' => [
+                                ['name' => 'symfony', 'symfony' => []]
+                            ]
+                        ]
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -31,12 +40,13 @@ Feature: Mink context integration
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
         use Behat\Mink\Mink;
         use Behat\Mink\Session;
         use Behat\MinkExtension\Context\MinkContext;
 
         final class SomeContext extends MinkContext implements Context {
-            /** @Then I should have Mink injected */
+            #[Then('I should have Mink injected')]
             public function shouldHaveMinkInjected(): void
             {
                 assert($this->getMink() instanceof Mink);

--- a/features/mink_integration/mink_default_session_and_parameters_integration.feature
+++ b/features/mink_integration/mink_default_session_and_parameters_integration.feature
@@ -4,18 +4,28 @@ Feature: Mink default session and parameters integration
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                Behat\MinkExtension:
-                    base_url: "http://localhost:8080/"
-                    default_session: symfony
-                    sessions:
-                        symfony:
-                            symfony: ~
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \Behat\MinkExtension\ServiceContainer\MinkExtension::class,
+                        [
+                            'base_url' => 'http://localhost:8080/',
+                            'default_session' => 'symfony',
+                            'sessions' => [
+                                ['name' => 'symfony', 'symfony' => []]
+                            ]
+                        ]
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -39,6 +49,8 @@ Feature: Mink default session and parameters integration
 
         use Behat\Behat\Context\Context;
         use Behat\Mink\Session;
+        use Behat\Step\Then;
+        use Behat\Step\When;
         use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
         use Psr\Container\ContainerInterface;
 
@@ -52,19 +64,19 @@ Feature: Mink default session and parameters integration
                 $this->parameters = $minkParameters;
             }
 
-            /** @When I visit the page :page */
+            #[When('I visit the page :page')]
             public function visitPage(string $page): void
             {
                 $this->session->visit($page);
             }
 
-            /** @Then I should see :content on the page */
+            #[Then('I should see :content on the page')]
             public function shouldSeeContentOnPage(string $content): void
             {
                 assert(false !== strpos($this->session->getPage()->getContent(), $content));
             }
 
-            /** @Then the base url from Mink parameters should be :expected */
+            #[Then('the base url from Mink parameters should be :expected')]
             public function baseUrlShouldBe(string $expected): void
             {
                 assert(isset($this->parameters['base_url']));

--- a/features/mink_integration/mink_service_integration.feature
+++ b/features/mink_integration/mink_service_integration.feature
@@ -4,18 +4,28 @@ Feature: Mink service integration
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                Behat\MinkExtension:
-                    base_url: "http://localhost:8080/"
-                    default_session: symfony
-                    sessions:
-                        symfony:
-                            symfony: ~
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \Behat\MinkExtension\ServiceContainer\MinkExtension::class,
+                        [
+                            'base_url' => 'http://localhost:8080/',
+                            'default_session' => 'symfony',
+                            'sessions' => [
+                                ['name' => 'symfony', 'symfony' => []]
+                            ]
+                        ]
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -37,6 +47,8 @@ Feature: Mink service integration
 
         use Behat\Behat\Context\Context;
         use Behat\Mink\Mink;
+        use Behat\Step\Then;
+        use Behat\Step\When;
         use Psr\Container\ContainerInterface;
 
         final class SomeContext implements Context {
@@ -47,13 +59,13 @@ Feature: Mink service integration
                 $this->mink = $mink;
             }
 
-            /** @When I visit the page :page */
+            #[When('I visit the page :page')]
             public function visitPage(string $page): void
             {
                 $this->mink->getSession()->visit($page);
             }
 
-            /** @Then I should see :content on the page */
+            #[Then('I should see :content on the page')]
             public function shouldSeeContentOnPage(string $content): void
             {
                 assert(false !== strpos($this->mink->getSession()->getPage()->getContent(), $content));

--- a/features/mink_integration/resetting_service_container_state.feature
+++ b/features/mink_integration/resetting_service_container_state.feature
@@ -4,18 +4,28 @@ Feature: Resetting the driver's service container in the right places
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                Behat\MinkExtension:
-                    base_url: "http://localhost:8080/"
-                    default_session: symfony
-                    sessions:
-                        symfony:
-                            symfony: ~
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \Behat\MinkExtension\ServiceContainer\MinkExtension::class,
+                        [
+                            'base_url' => 'http://localhost:8080/',
+                            'default_session' => 'symfony',
+                            'sessions' => [
+                                ['name' => 'symfony', 'symfony' => []]
+                            ]
+                        ]
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a YAML services file containing:
         """
@@ -35,6 +45,9 @@ Feature: Resetting the driver's service container in the right places
         use App\Counter;
         use Behat\Behat\Context\Context;
         use Behat\Mink\Mink;
+        use Behat\Step\Given;
+        use Behat\Step\Then;
+        use Behat\Step\When;
         use Symfony\Component\DependencyInjection\ContainerInterface;
 
         final class SomeContext implements Context {
@@ -47,31 +60,31 @@ Feature: Resetting the driver's service container in the right places
                 $this->driverContainer = $driverContainer;
             }
 
-            /** @Given the counter service is zeroed */
+            #[Given('the counter service is zeroed')]
             public function counterServiceIsZeroed(): void
             {
                 assert(0 === $this->getCounterService()->get());
             }
 
-            /** @When I visit the page :page */
+            #[When('I visit the page :page')]
             public function visitPage(string $page): void
             {
                 $this->mink->getSession()->visit($page);
             }
 
-            /** @When I increment the counter */
+            #[When('I increment the counter')]
             public function incrementCounter(): void
             {
                 $this->getCounterService()->increase();
             }
 
-            /** @Then the counter service should return :number */
+            #[Then('the counter service should return :number')]
             public function counterServiceShouldReturn(int $number): void
             {
                 assert($number === $this->getCounterService()->get());
             }
 
-            /** @Then I should see :content on the page */
+            #[Then('I should see :content on the page')]
             public function shouldSeeContentOnPage(string $content): void
             {
                 assert(false !== strpos($this->mink->getSession()->getPage()->getContent(), $content));

--- a/features/mink_integration/switching_mink_sessions.feature
+++ b/features/mink_integration/switching_mink_sessions.feature
@@ -4,23 +4,30 @@ Feature: Switching Mink sessions
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                Behat\MinkExtension:
-                    base_url: "http://localhost:8080/"
-                    default_session: symfony
-                    javascript_session: selenium2
-                    sessions:
-                        symfony:
-                            symfony: ~
-                        selenium2:
-                            selenium2: ~
+        <?php
 
-
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \Behat\MinkExtension\ServiceContainer\MinkExtension::class,
+                        [
+                            'base_url' => 'http://localhost:8080/',
+                            'default_session' => 'symfony',
+                            'javascript_session' => 'selenium2',
+                            'sessions' => [
+                                ['name' => 'symfony', 'symfony' => []],
+                                ['name' =>'selenium2', 'selenium2' => []],
+                            ]
+                        ]
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -40,6 +47,7 @@ Feature: Switching Mink sessions
 
         use Behat\Behat\Context\Context;
         use Behat\Mink\Session;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             private $session;
@@ -49,7 +57,7 @@ Feature: Switching Mink sessions
                 $this->session = $session;
             }
 
-            /** @Then I should use Mink session with :driver as a driver*/
+            #[Then('I should use Mink session with :driver as a driver')]
             public function shouldUseDriver(string $driverClass): void
             {
                 assert($this->session->getDriver() instanceof $driverClass);

--- a/features/sanity_checks/accessing_a_context_in_another_context.feature
+++ b/features/sanity_checks/accessing_a_context_in_another_context.feature
@@ -4,12 +4,16 @@ Feature: Accessing a context in another context
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
-                        - App\Tests\AnotherContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext', 'App\Tests\AnotherContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -37,12 +41,14 @@ Feature: Accessing a context in another context
 
         use Behat\Behat\Context\Context;
         use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+        use Behat\Hook\BeforeScenario;
+        use Behat\Step\Then;
 
         final class AnotherContext implements Context {
             /** @var SomeContext */
             private $someContext;
 
-            /** @BeforeScenario */
+            #[BeforeScenario()]
             public function gatherContexts(BeforeScenarioScope $scope)
             {
                 $environment = $scope->getEnvironment();
@@ -50,7 +56,7 @@ Feature: Accessing a context in another context
                 $this->someContext = $environment->getContext('App\Tests\SomeContext');
             }
 
-            /** @Then it should pass */
+            #[Then('it should pass')]
             public function itShouldPass(): void
             {
                 $this->someContext->someMethod();

--- a/features/sanity_checks/class_resolvers_compatibility.feature
+++ b/features/sanity_checks/class_resolvers_compatibility.feature
@@ -4,16 +4,22 @@ Feature: Class resolvers compatibility
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\ServiceContainerExtension:
-                    imports:
-                        - "tests/class_resolver.yml"
+        <?php
 
-            suites:
-                default:
-                    contexts:
-                        - class:resolved:context
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \FriendsOfBehat\ServiceContainerExtension\ServiceContainer\ServiceContainerExtension::class,
+                        ['imports' => ['tests/class_resolver.yml']]
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('class:resolved:context')
+                    )
+            );
         """
         And a Behat services definition file "tests/class_resolver.yml" containing:
         """
@@ -55,9 +61,10 @@ Feature: Class resolvers compatibility
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
-            /** @Then it should pass */
+            #[Then('it should pass')]
             public function itShouldPass(): void {}
         }
         """

--- a/features/sanity_checks/context_constructor_dependency_injection_compatibility.feature
+++ b/features/sanity_checks/context_constructor_dependency_injection_compatibility.feature
@@ -4,15 +4,24 @@ Feature: Context constructor dependency injection compatibility
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext:
-                            - "@App\\Foo"
+        <?php
 
-                    services:
-                        App\Foo: ~
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite(
+                            'default',
+                            [
+                                'services' => [
+                                    'App\Foo' => ['class' => 'App\Foo']
+                                ]
+                            ]
+                        )
+                    )
+                    ->addContext('App\Tests\SomeContext', ['@App\\Foo'])
+                )
+            );
         """
         And a class file "src/Foo.php" containing:
         """
@@ -38,6 +47,7 @@ Feature: Context constructor dependency injection compatibility
 
         use App\Foo;
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             public function __construct(Foo $foo)
@@ -45,7 +55,7 @@ Feature: Context constructor dependency injection compatibility
                 $this->foo = $foo;
             }
 
-            /** @Then it should pass */
+            #[Then('it should pass')]
             public function itShouldPass(): void
             {
                 assert($this->foo instanceof Foo);

--- a/features/sanity_checks/context_initializer_compatibility.feature
+++ b/features/sanity_checks/context_initializer_compatibility.feature
@@ -4,16 +4,22 @@ Feature: Context initializer compatibility
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\ServiceContainerExtension:
-                    imports:
-                        - "tests/context_initializer.yml"
+        <?php
 
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \FriendsOfBehat\ServiceContainerExtension\ServiceContainer\ServiceContainerExtension::class,
+                        ['imports' => ['tests/context_initializer.yml']]
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a Behat services definition file "tests/context_initializer.yml" containing:
         """
@@ -51,6 +57,7 @@ Feature: Context initializer compatibility
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             private $shouldPass = false;
@@ -60,7 +67,7 @@ Feature: Context initializer compatibility
                 $this->shouldPass = $shouldPass;
             }
 
-            /** @Then it should pass */
+            #[Then('it should pass')]
             public function itShouldPass(): void
             {
                 assert($this->shouldPass === true);

--- a/features/sanity_checks/context_initializer_instantiation.feature
+++ b/features/sanity_checks/context_initializer_instantiation.feature
@@ -6,16 +6,22 @@ Feature: instantiation of a context initializer
     Given a working Symfony application with SymfonyExtension configured
     And a Behat configuration containing:
         """
-        default:
-            extensions:
-                FriendsOfBehat\ServiceContainerExtension:
-                    imports:
-                        - "tests/context_initializer.yml"
+        <?php
 
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withExtension(
+                      new \Behat\Config\Extension(
+                        \FriendsOfBehat\ServiceContainerExtension\ServiceContainer\ServiceContainerExtension::class,
+                        ['imports' => ['tests/context_initializer.yml']]
+                      )
+                    )
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
     And a Behat services definition file "tests/context_initializer.yml" containing:
         """
@@ -48,7 +54,7 @@ Feature: instantiation of a context initializer
                 $context->makeItPass(true);
             }
 
-            public static function getSubscribedEvents()
+            public static function getSubscribedEvents(): array
             {
                 return [];
             }
@@ -67,6 +73,7 @@ Feature: instantiation of a context initializer
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
             private $shouldPass = false;
@@ -76,7 +83,7 @@ Feature: instantiation of a context initializer
                 $this->shouldPass = $shouldPass;
             }
 
-            /** @Then it should pass */
+            #[Then('it should pass')]
             public function itShouldPass(): void
             {
                 $actualInitializersCount = CustomContextInitializer::$counter;

--- a/features/sanity_checks/isolating_contexts.feature
+++ b/features/sanity_checks/isolating_contexts.feature
@@ -4,11 +4,16 @@ Feature: Isolating contexts
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -30,6 +35,8 @@ Feature: Isolating contexts
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
+        use Behat\Step\When;
         use Psr\Container\ContainerInterface;
 
         final class SomeContext implements Context {
@@ -37,10 +44,10 @@ Feature: Isolating contexts
 
             public function __construct(?ContainerInterface $container = null) { $this->container = $container; }
 
-            /** @When I change the property to :value */
+            #[When('I change the property to :value')]
             public function changeProperty(string $value): void { $this->property = $value; }
 
-            /** @Then the property should be :expected*/
+            #[Then('the property should be :expected')]
             public function propertyShouldBe(string $expected): void { assert($this->property === $expected); }
         }
         """

--- a/features/sanity_checks/running_bare_behat_scenarios.feature
+++ b/features/sanity_checks/running_bare_behat_scenarios.feature
@@ -4,11 +4,16 @@ Feature: Running bare Behat scenarios
         Given a working Symfony application with SymfonyExtension configured
         And a Behat configuration containing:
         """
-        default:
-            suites:
-                default:
-                    contexts:
-                        - App\Tests\SomeContext
+        <?php
+
+        return (new \Behat\Config\Config())
+            ->withProfile(
+                (new \Behat\Config\Profile('default'))
+                    ->withSuite(
+                        (new \Behat\Config\Suite('default'))
+                            ->withContexts('App\Tests\SomeContext')
+                    )
+            );
         """
         And a feature file containing:
         """
@@ -23,9 +28,10 @@ Feature: Running bare Behat scenarios
         namespace App\Tests;
 
         use Behat\Behat\Context\Context;
+        use Behat\Step\Then;
 
         final class SomeContext implements Context {
-            /** @Then it should pass */
+            #[Then('it should pass')]
             public function itShouldPass(): void {}
         }
         """

--- a/src/Context/Environment/InitializedSymfonyExtensionEnvironment.php
+++ b/src/Context/Environment/InitializedSymfonyExtensionEnvironment.php
@@ -15,6 +15,7 @@ namespace FriendsOfBehat\SymfonyExtension\Context\Environment;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Exception\ContextNotFoundException;
+use Behat\Behat\Context\LateBoundContextMethodCallable;
 use Behat\Testwork\Call\Callee;
 use Behat\Testwork\Suite\Suite;
 use FriendsOfBehat\SymfonyExtension\Context\Environment\Handler\ContextServiceEnvironmentHandler;
@@ -53,6 +54,10 @@ final class InitializedSymfonyExtensionEnvironment implements SymfonyExtensionEn
     public function bindCallee(Callee $callee): callable
     {
         $callable = $callee->getCallable();
+
+        if ($callable instanceof LateBoundContextMethodCallable) {
+            return $callable->bindTo($this->getContext($callable->contextClass));
+        }
 
         if (is_array($callable) && $callee->isAnInstanceMethod()) {
             return [$this->getContext($callable[0]), $callable[1]];

--- a/tests/Behat/Context/TestContext.php
+++ b/tests/Behat/Context/TestContext.php
@@ -5,10 +5,16 @@ declare(strict_types=1);
 namespace Tests\Behat\Context;
 
 use Behat\Behat\Context\Context;
+use Behat\Config\Config;
+use Behat\Hook\AfterScenario;
+use Behat\Hook\BeforeFeature;
+use Behat\Hook\BeforeScenario;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Yaml\Yaml;
 
 final class TestContext implements Context
 {
@@ -27,9 +33,7 @@ final class TestContext implements Context
     /** @var array */
     private $variables = [];
 
-    /**
-     * @BeforeFeature
-     */
+    #[BeforeFeature()]
     public static function beforeFeature(): void
     {
         self::$workingDir = sprintf('%s/%s/', sys_get_temp_dir(), uniqid('', true));
@@ -37,26 +41,20 @@ final class TestContext implements Context
         self::$phpBin = self::findPhpBinary();
     }
 
-    /**
-     * @BeforeScenario
-     */
+    #[BeforeScenario()]
     public function beforeScenario(): void
     {
         self::$filesystem->remove(self::$workingDir);
         self::$filesystem->mkdir(self::$workingDir, 0777);
     }
 
-    /**
-     * @AfterScenario
-     */
+    #[AfterScenario()]
     public function afterScenario(): void
     {
         self::$filesystem->remove(self::$workingDir);
     }
 
-    /**
-     * @Given a standard Symfony autoloader configured
-     */
+    #[Given('a standard Symfony autoloader configured')]
     public function standardSymfonyAutoloaderConfigured(): void
     {
         $this->thereIsFile('vendor/autoload.php', sprintf(<<<'CON'
@@ -73,18 +71,25 @@ CON
             , __DIR__ . '/../../../vendor/autoload.php'));
     }
 
-    /**
-     * @Given a working Symfony application with SymfonyExtension configured
-     */
+    #[Given('a working Symfony application with SymfonyExtension configured')]
     public function workingSymfonyApplicationWithExtension(): void
     {
         $this->thereIsConfiguration(
             <<<'CON'
-default:
-    extensions:
-        FriendsOfBehat\SymfonyExtension:
-            kernel:
-                class: App\Kernel
+<?php
+
+return (new \Behat\Config\Config())
+    ->withProfile(
+        (new \Behat\Config\Profile('default'))
+            ->withExtension(new \Behat\Config\Extension(
+                'FriendsOfBehat\SymfonyExtension\ServiceContainer\SymfonyExtension',
+                [
+                    'kernel' => [
+                        'class' => 'App\Kernel',
+                    ]                
+                ]
+            ))
+    );
 CON
         );
 
@@ -216,45 +221,39 @@ YML
         $this->thereIsFile('config/services.yaml', '');
     }
 
-    /**
-     * @Given /^an? (server|environment) variable "([^"]++)" set to "([^"]++)"$/
-     */
+    #[Given('/^an? (server|environment) variable "([^"]++)" set to "([^"]++)"$/')]
     public function variableSetTo(string $type, string $name, string $value): void
     {
         $this->variables[$type][$name] = $value;
     }
 
-    /**
-     * @Given /^a YAML services file containing:$/
-     */
+    #[Given('/^a YAML services file containing:$/')]
     public function yamlServicesFile($content): void
     {
         $this->thereIsFile('config/services.yaml', (string) $content);
     }
 
-    /**
-     * @Given /^a Behat configuration containing(?: "([^"]+)"|:)$/
-     */
+    #[Given('/^a Behat configuration containing(?: "([^"]+)"|:)$/')]
     public function thereIsConfiguration($content): void
     {
-        $mainConfigFile = sprintf('%s/behat.yml', self::$workingDir);
-        $newConfigFile = sprintf('%s/behat-%s.yml', self::$workingDir, md5((string) $content));
+        $mainConfigFile = sprintf('%s/behat.php', self::$workingDir);
+        $newConfigFile = sprintf('%s/behat-%s.php', self::$workingDir, md5((string) $content));
 
-        self::$filesystem->dumpFile($newConfigFile, (string) $content);
+        $config = eval('?>'.$content);
+
+        self::$filesystem->dumpFile($newConfigFile, $this->outputConfig($config));
 
         if (!file_exists($mainConfigFile)) {
-            self::$filesystem->dumpFile($mainConfigFile, Yaml::dump(['imports' => []]));
+            self::$filesystem->dumpFile($mainConfigFile, $this->outputConfig(new Config()));
         }
 
-        $mainBehatConfiguration = Yaml::parseFile($mainConfigFile);
-        $mainBehatConfiguration['imports'][] = $newConfigFile;
+        $mainBehatConfiguration = require $mainConfigFile;
+        $mainBehatConfiguration->import($newConfigFile);
 
-        self::$filesystem->dumpFile($mainConfigFile, Yaml::dump($mainBehatConfiguration));
+        self::$filesystem->dumpFile($mainConfigFile, $this->outputConfig($mainBehatConfiguration));
     }
 
-    /**
-     * @Given /^a (?:.+ |)file "([^"]+)" containing(?: "([^"]+)"|:)$/
-     */
+    #[Given('/^a (?:.+ |)file "([^"]+)" containing(?: "([^"]+)"|:)$/')]
     public function thereIsFile($file, $content): string
     {
         $path = self::$workingDir . '/' . $file;
@@ -264,17 +263,13 @@ YML
         return $path;
     }
 
-    /**
-     * @Given /^a feature file containing(?: "([^"]+)"|:)$/
-     */
+    #[Given('/^a feature file containing(?: "([^"]+)"|:)$/')]
     public function thereIsFeatureFile($content): void
     {
         $this->thereIsFile(sprintf('features/%s.feature', md5(uniqid('', true))), $content);
     }
 
-    /**
-     * @When /^I run Behat$/
-     */
+    #[When('/^I run Behat$/')]
     public function iRunBehat(): void
     {
         $executablePath = BEHAT_BIN_PATH;
@@ -300,9 +295,7 @@ YML
         $this->process->wait();
     }
 
-    /**
-     * @Then /^it should pass$/
-     */
+    #[Then('/^it should pass$/')]
     public function itShouldPass(): void
     {
         if (0 === $this->getProcessExitCode()) {
@@ -314,18 +307,14 @@ YML
         );
     }
 
-    /**
-     * @Then /^it should pass with(?: "([^"]+)"|:)$/
-     */
+    #[Then('/^it should pass with(?: "([^"]+)"|:)$/')]
     public function itShouldPassWith($expectedOutput): void
     {
         $this->itShouldPass();
         $this->assertOutputMatches((string) $expectedOutput);
     }
 
-    /**
-     * @Then /^it should fail$/
-     */
+    #[Then('/^it should fail$/')]
     public function itShouldFail(): void
     {
         if (0 !== $this->getProcessExitCode()) {
@@ -337,21 +326,22 @@ YML
         );
     }
 
-    /**
-     * @Then /^it should fail with(?: "([^"]+)"|:)$/
-     */
+    #[Then('/^it should fail with(?: "([^"]+)"|:)$/')]
     public function itShouldFailWith($expectedOutput): void
     {
         $this->itShouldFail();
         $this->assertOutputMatches((string) $expectedOutput);
     }
 
-    /**
-     * @Then /^it should end with(?: "([^"]+)"|:)$/
-     */
+    #[Then('/^it should end with(?: "([^"]+)"|:)$/')]
     public function itShouldEndWith($expectedOutput): void
     {
         $this->assertOutputMatches((string) $expectedOutput);
+    }
+
+    private function outputConfig(Config $config): string
+    {
+        return sprintf('<?php return unserialize(\'%s\');', serialize($config));
     }
 
     /**


### PR DESCRIPTION
Adds support for Behat 4.x, which drops two things this extension and its test suite relied on: YAML configuration and doc-block annotations (both replaced: config by PHP files, step/hook definitions by PHP 8 attributes).

### Production change
  
  - `InitializedSymfonyExtensionEnvironment::bindCallee()` now handles Behat 4's new `LateBoundContextMethodCallable`, binding it to the resolved context instance via `bindTo()`. This is the one code change needed for the extension itself to work under Behat 4 (per the changelog's "use explicit type for late-bound Context callable methods").

### Test suite migration (Behat 4 dropped YAML config + annotations)

  - Replaced `behat.yml.dist` with `behat.dist.php` using the new `Config`/`Profile`/`Suite` builder objects.
  - Migrated `TestContext` from `@Given`/`@When`/`@Then`/`@BeforeScenario` annotations to `#[Given]`/`#[When]`/`#[Then]`/`#[BeforeScenario]` attributes.
  - `TestContext::thereIsConfiguration()` now generates PHP config files (`behat.php`), eval-ing the inline PHP snippet into a `Config` object and persisting it via `serialize()`/`unserialize()` rather than parsing/dumping YAML.
  - Updated all feature files to use PHP-based Behat configuration and attribute-based step definitions in their inline fixtures.

This PR depends on https://github.com/FriendsOfBehat/MinkExtension/pull/58